### PR TITLE
create first version of importing data from file in building view and small styling edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-scripts": "^5.0.1",
     "styled-components": "^5.3.5",
     "util": "^0.12.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/building/AddBuildingContainer.js
+++ b/src/components/building/AddBuildingContainer.js
@@ -9,6 +9,7 @@ import {
 } from "../../validation/ValidateAddBuilding";
 import dao from "../../ajax/dao";
 import AddBuildingForm from "./AddBuildingForm";
+import ImportBuilding from "./ImportBuilding";
 
 export default function AddBuildingContainer(props) {
   const { getAllBuildings } = props;
@@ -99,6 +100,7 @@ export default function AddBuildingContainer(props) {
             submitValues={formik.values}
             setInitialBuilding={setInitialBuilding}
           />
+          <ImportBuilding getAllBuildings={getAllBuildings} />
         </CardContent>
       </Card>
     </React.Fragment>

--- a/src/components/building/ImportBuilding.js
+++ b/src/components/building/ImportBuilding.js
@@ -1,0 +1,139 @@
+import React, { useState } from "react";
+import * as XLSX from "xlsx";
+import { Typography } from "@mui/material";
+import AlertBox from "../common/AlertBox";
+import {
+  validate,
+  capitalizeFirstLetter,
+} from "../../validation/ValidateAddBuilding";
+import dao from "../../ajax/dao";
+import Button from "@mui/material/Button";
+import Input from "@mui/material/Input";
+
+export default function ImportBuilding(props) {
+  const { getAllBuildings } = props;
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertOptions, setAlertOptions] = useState({
+    title: "This is title",
+    message: "This is an error alert — check it out!",
+    severity: "error",
+  });
+
+  //data import
+  const [importBuildings, setImportBuildings] = useState([]);
+  const [failedBuildings, setFailedBuildings] = useState([]);
+
+  const handleFileUpload = async (e) => {
+    const file = e.target.files[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (
+      file.type !== "application/vnd.ms-excel" &&
+      file.type !==
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
+      file.type !== "text/csv"
+    ) {
+      setAlertOptions({
+        title: "Invalid file type",
+        message: "Please upload a .xlsx or .csv file.",
+        severity: "error",
+      });
+      setAlertOpen(true);
+      return;
+    }
+
+    const data = await file.arrayBuffer();
+    const workbook = XLSX.read(data);
+    const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+    const parsedData = XLSX.utils.sheet_to_json(worksheet);
+    setImportBuildings(parsedData);
+  };
+
+  const importData = async () => {
+    let successCount = 0;
+    let failedCount = 0;
+    let tempFailedBuildings = [];
+
+    await Promise.all(
+      importBuildings.map(async (building) => {
+        let newBuilding = {
+          name: building.name ? capitalizeFirstLetter(building.name) : "",
+          description: building.description ? building.description : "",
+        };
+
+        const validateResult = await validate(newBuilding);
+
+        if (Object.keys(validateResult).length !== 0) {
+          tempFailedBuildings.push(building);
+          failedCount++;
+
+          return;
+        }
+
+        let result = await dao.postNewBuilding(newBuilding);
+
+        if (!result) {
+          tempFailedBuildings.push(building);
+          failedCount++;
+        } else {
+          getAllBuildings();
+          successCount++;
+        }
+      }),
+    );
+
+    setFailedBuildings([...failedBuildings, ...tempFailedBuildings]);
+
+    setAlertOptions({
+      severity: "success",
+      title: "Success!",
+      message: `${successCount} building added and ${failedCount} building failed to add.`,
+    });
+    setAlertOpen(true);
+  };
+
+  const exportData = async () => {
+    let workbook_fail = XLSX.utils.book_new();
+    let worksheet_fail = XLSX.utils.json_to_sheet(failedBuildings);
+
+    XLSX.utils.book_append_sheet(workbook_fail, worksheet_fail, "Buildings");
+    XLSX.writeFile(workbook_fail, "BuildingsFailedToImport.xlsx");
+  };
+
+  return (
+    <React.Fragment>
+      <AlertBox
+        alertOpen={alertOpen}
+        alertOptions={alertOptions}
+        setAlertOpen={setAlertOpen}
+      />
+      <Typography>Import from .xlsx or .csv file</Typography>
+      <Input
+        variant="sibaInputFileName"
+        type="file"
+        accept=".xlsx, .xls, .csv"
+        onChange={handleFileUpload}
+      />
+      <Button
+        variant="contained"
+        onClick={() => {
+          importData();
+        }}
+      >
+        Import data
+      </Button>
+      <Button
+        variant="contained"
+        color="red"
+        onClick={() => {
+          exportData();
+        }}
+      >
+        Export failed data
+      </Button>
+    </React.Fragment>
+  );
+}

--- a/src/components/subject/AddSubjectForm.js
+++ b/src/components/subject/AddSubjectForm.js
@@ -172,7 +172,7 @@ export default function AddSubjectForm(props) {
             </FormControl>
           </Grid>
           <Grid item xs={12}>
-            <Typography variant="h6" sx={{ color: "#F6E9E9" }}>
+            <Typography variant="sibaTypography">
               Copy the information from another lesson
             </Typography>
           </Grid>

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -421,6 +421,7 @@ const theme = createTheme({
             borderColor: currentPalette.backgroundDarker.default,
             fontSize: "1.2rem",
             display: "contents",
+            // color: currentPalette.fontColorDefault.main,
             "& a": {
               padding: "0.5rem 1rem",
               borderBottom: "3px solid transparent",
@@ -673,6 +674,16 @@ const theme = createTheme({
           fontSize: "1.2rem",
         },
       },
+    },
+    MuiInput: {
+      variants: [
+        {
+          props: { variant: "sibaInputFileName" },
+          style: {
+            color: light,
+          },
+        },
+      ],
     },
   },
 });


### PR DESCRIPTION
I made a simple version of import data for Building view. Some functionalities: 
- Choosing file to import
- Import button to import to database
- Export button to export failed data that cannot be imported as a .xlsx file 
- Alert showing wrong file types, how many buildings imported successfully and failed

Supported file: .xlsx or .csv
If the file has multiple pages, only the first page is read.
It is handling building import, so the data "format"  must be like this, so that building can be imported: (column name not capitalized, but order of columns does not matter, row data will be validated the same as adding 1 Building manually).

name	description
building 1	Test 1
Building 2	Test 2
Building 3	Test 3