### PR TITLE
Improve search input placeholders

### DIFF
--- a/src/components/subject/SubjectFiltering.js
+++ b/src/components/subject/SubjectFiltering.js
@@ -34,7 +34,7 @@ export default function SubjectFiltering({
   return (
     <TextField
       name="searched"
-      placeholder="Opetusten haku:"
+      placeholder="Search lessons"
       type="text"
       variant="outlined"
       fullWidth

--- a/src/components/user/UserFiltering.js
+++ b/src/components/user/UserFiltering.js
@@ -33,7 +33,7 @@ export default function UserFiltering({
   return (
     <TextField
       name="searched"
-      placeholder="Käyttäjien haku:"
+      placeholder="Search users"
       type="text"
       variant="outlined"
       fullWidth


### PR DESCRIPTION
Use English, as in the rest of UI, and drop the extra colon.