### PR TITLE
Allow using PORT env var with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.2.2",
     "@types/luxon": "^3.3.2",
+    "@types/node": "^20.8.3",
     "@types/react": "^18.2.25",
     "@types/react-dom": "^18.2.10",
     "@vitejs/plugin-react": "^4.1.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-});
+
+export default ({ mode }) => {
+  const { PORT } = loadEnv(mode, process.cwd(), "");
+
+  return defineConfig({
+    plugins: [react()],
+    server: {
+      port: PORT && Number(PORT),
+    },
+  });
+};


### PR DESCRIPTION
This makes Vite to respect the `PORT` environment variable if defined in a `.env` file.