### PR TITLE
fixes room results spacing for half screen viewport size

### DIFF
--- a/src/components/room/RoomsWithTimesList.jsx
+++ b/src/components/room/RoomsWithTimesList.jsx
@@ -12,7 +12,7 @@ export default function RoomsWithTimesList({ rooms }) {
     <Grid2
       key="container for list"
       container
-      rowSpacing={1}
+      rowSpacing={3}
       columnSpacing={{ xs: 1, sm: 2, md: 3 }}
       spacing={2}
       variant="resultContainer"


### PR DESCRIPTION
After studying the code for a while I was able to find a way to fix the room result spacing for a half-screen viewport size without having to refactor the components so that's nice. 👍