### PR TITLE
Add lesson/subject error messages + minor button changes

### DIFF
--- a/src/components/department/AddDepartment.jsx
+++ b/src/components/department/AddDepartment.jsx
@@ -84,7 +84,10 @@ export default function AddDepartment({ getAllDepartments }) {
                 />
               </Grid>
               <Grid item xs={12}>
-                <Button onClick={() => openDialogBox()} variant="contained">
+                <Button
+                  onClick={() => openDialogBox()}
+                  variant="addComponentFormButton"
+                >
                   Add Department
                 </Button>
               </Grid>

--- a/src/components/subject/AddSubjectContainer.jsx
+++ b/src/components/subject/AddSubjectContainer.jsx
@@ -78,7 +78,7 @@ export default function AddSubjectContainer({
     enableReinitialize: true,
     initialValues: initialSubject,
     validate: (values) => {
-      validate(values, allocRoundContext.allocRoundId);
+      return validate(values, allocRoundContext.allocRoundId);
     },
     onSubmit: (values) => {
       setDialogOptions({

--- a/src/components/subject/AddSubjectForm.jsx
+++ b/src/components/subject/AddSubjectForm.jsx
@@ -100,7 +100,11 @@ export default function AddSubjectForm({
               value={formik.values.name}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              helperText={formik.touched.name && formik.errors.name}
+              helperText={
+                formik.touched.name && formik.errors.name
+                  ? formik.errors.name
+                  : null
+              }
               InputLabelProps={{
                 shrink: true,
               }}
@@ -117,7 +121,11 @@ export default function AddSubjectForm({
               value={formik.values.groupSize}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              helperText={formik.touched.groupSize && formik.errors.groupSize}
+              helperText={
+                formik.touched.groupSize && formik.errors.groupSize
+                  ? formik.errors.groupSize
+                  : null
+              }
               InputLabelProps={{
                 shrink: true,
               }}
@@ -134,7 +142,11 @@ export default function AddSubjectForm({
               value={formik.values.groupCount}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              helperText={formik.touched.groupCount && formik.errors.groupCount}
+              helperText={
+                formik.touched.groupCount && formik.errors.groupCount
+                  ? formik.errors.groupCount
+                  : null
+              }
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4} lg={3}>
@@ -152,6 +164,8 @@ export default function AddSubjectForm({
               placeholder="hh:mm"
               helperText={
                 formik.touched.sessionLength && formik.errors.sessionLength
+                  ? formik.errors.sessionLength
+                  : null
               }
               InputLabelProps={{
                 shrink: true,
@@ -172,6 +186,8 @@ export default function AddSubjectForm({
               onBlur={formik.handleBlur}
               helperText={
                 formik.touched.sessionCount && formik.errors.sessionCount
+                  ? formik.errors.sessionCount
+                  : null
               }
             />
           </Grid>
@@ -184,7 +200,11 @@ export default function AddSubjectForm({
               value={formik.values.area}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
-              helperText={formik.touched.area && formik.errors.area}
+              helperText={
+                formik.touched.area && formik.errors.area
+                  ? formik.errors.area
+                  : null
+              }
             />
           </Grid>
           <Grid item xs={12} sm={12} md={6} lg={3}>

--- a/src/components/user/AddUser.jsx
+++ b/src/components/user/AddUser.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -19,7 +19,7 @@ import AddUserDialogConfirmations from "./AddUserDialogConfirmations";
 
 export default function AddUser({ getAllUsers }) {
   const [isCardExpanded, setIsCardExpanded] = useState(false);
-  
+
   const [open, setOpen] = useState(false);
   const [registerForm, setRegisterForm] = useState({
     email: "",
@@ -48,110 +48,116 @@ export default function AddUser({ getAllUsers }) {
       <Card variant="outlined">
         <CardContent>
           <CardHeader
-              title="Add User"
-              onClick={() => setIsCardExpanded(!isCardExpanded)}
-              variant="pageHeader"
-              action={
-                <IconButton
-                  onClick={() => setIsCardExpanded(!isCardExpanded)}
-                  aria-expanded={isCardExpanded}
-                  aria-label="expand/collapse"
-                  color="primary"
-                >
-                  {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                </IconButton>
-              }
-            />
-            {isCardExpanded && (
-              <Grid container spacing={2}>
-                <Grid item xs={12}>
-                  <TextField
-                    className="formTextInput"
-                    value={registerForm.email}
-                    onChange={(event) =>
-                      setRegisterForm({ ...registerForm, email: event.target.value })
-                    }
-                    placeholder="email"
-                  />
-                </Grid>
-                <Grid item xs={12}>
-                  <TextField
-                    className="formTextInput"
-                    value={registerForm.password}
+            title="Add User"
+            onClick={() => setIsCardExpanded(!isCardExpanded)}
+            variant="pageHeader"
+            action={
+              <IconButton
+                onClick={() => setIsCardExpanded(!isCardExpanded)}
+                aria-expanded={isCardExpanded}
+                aria-label="expand/collapse"
+                color="primary"
+              >
+                {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              </IconButton>
+            }
+          />
+          {isCardExpanded && (
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <TextField
+                  className="formTextInput"
+                  value={registerForm.email}
+                  onChange={(event) =>
+                    setRegisterForm({
+                      ...registerForm,
+                      email: event.target.value,
+                    })
+                  }
+                  placeholder="email"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  className="formTextInput"
+                  value={registerForm.password}
+                  onChange={(event) =>
+                    setRegisterForm({
+                      ...registerForm,
+                      password: event.target.value,
+                    })
+                  }
+                  type={showPassword ? "text" : "password"}
+                  placeholder="password"
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={handlePasswordVisibility}
+                          edge="end"
+                          style={{ backgroundColor: "transparent" }}
+                        >
+                          {showPassword ? <Visibility /> : <VisibilityOff />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <FormGroup>
+                  <FormControlLabel
+                    control={<Checkbox />}
+                    label="Admin"
+                    labelPlacement="start"
+                    className="formCheckBoxButtons"
+                    name="isAdmin"
+                    checked={registerForm.isAdmin === 1}
                     onChange={(event) =>
                       setRegisterForm({
                         ...registerForm,
-                        password: event.target.value,
+                        isAdmin: event.target.checked ? 1 : 0,
                       })
                     }
-                    type={showPassword ? "text" : "password"}
-                    placeholder="password"
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            onClick={handlePasswordVisibility}
-                            edge="end"
-                            style={{ backgroundColor: "transparent" }}
-                          >
-                            {showPassword ? <Visibility /> : <VisibilityOff />}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
                   />
-                </Grid>
-                <Grid item xs={12} sm={6} md={4}>
-                  <FormGroup>
-                    <FormControlLabel
-                      control={<Checkbox />}
-                      label="Admin"
-                      labelPlacement="start"
-                      className="formCheckBoxButtons"
-                      name="isAdmin"
-                      checked={registerForm.isAdmin === 1}
-                      onChange={(event) =>
-                        setRegisterForm({
-                          ...registerForm,
-                          isAdmin: event.target.checked ? 1 : 0,
-                        })
-                      }
-                    />
-                    <FormControlLabel
-                      control={<Checkbox />}
-                      label="Planner"
-                      labelPlacement="start"
-                      className="formCheckBoxButtons"
-                      name="isPlanner"
-                      checked={registerForm.isPlanner === 1}
-                      onChange={(event) =>
-                        setRegisterForm({
-                          ...registerForm,
-                          isPlanner: event.target.checked ? 1 : 0,
-                        })
-                      }
-                    />
-                    <FormControlLabel
-                      control={<Checkbox />}
-                      label="Statist"
-                      labelPlacement="start"
-                      className="formCheckBoxButtons"
-                      name="isStatist"
-                      checked={registerForm.isStatist === 1}
-                      onChange={(event) =>
-                        setRegisterForm({
-                          ...registerForm,
-                          isStatist: event.target.checked ? 1 : 0,
-                        })
-                      }
-                    />
-                  </FormGroup>
-                  <Button onClick={() => openDialogBox()} variant="contained">
-                    Add User
-                  </Button>
-                </Grid>
+                  <FormControlLabel
+                    control={<Checkbox />}
+                    label="Planner"
+                    labelPlacement="start"
+                    className="formCheckBoxButtons"
+                    name="isPlanner"
+                    checked={registerForm.isPlanner === 1}
+                    onChange={(event) =>
+                      setRegisterForm({
+                        ...registerForm,
+                        isPlanner: event.target.checked ? 1 : 0,
+                      })
+                    }
+                  />
+                  <FormControlLabel
+                    control={<Checkbox />}
+                    label="Statist"
+                    labelPlacement="start"
+                    className="formCheckBoxButtons"
+                    name="isStatist"
+                    checked={registerForm.isStatist === 1}
+                    onChange={(event) =>
+                      setRegisterForm({
+                        ...registerForm,
+                        isStatist: event.target.checked ? 1 : 0,
+                      })
+                    }
+                  />
+                </FormGroup>
+                <Button
+                  onClick={() => openDialogBox()}
+                  variant="addComponentFormButton"
+                >
+                  Add User
+                </Button>
               </Grid>
-            )}
+            </Grid>
+          )}
         </CardContent>
       </Card>
       <AddUserDialogConfirmations
@@ -160,7 +166,7 @@ export default function AddUser({ getAllUsers }) {
         registerForm={registerForm}
         setRegisterForm={setRegisterForm}
         getAllUsers={getAllUsers}
-      />  
+      />
     </>
   );
 }


### PR DESCRIPTION
Making it so that the possible validation errors will show up as a helper text while editing the Add Lesson -form. 

I also thought I'd quickly change "add department" and "add user" -buttons to follow the styling of the rest of the add-buttons, but apparently it also did some auto-formatting changes to the AddUser-file so it looks like I did a lot more than I actually did...