### PR TITLE
Styling the failed allocation pop-up to look more visually pleasing

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -402,7 +402,7 @@ export const createAppTheme = (currentPalette) =>
           color: currentPalette.AllocRoom.musiikkiluokka.color,
         },
       },
-      RoomResultsContainer:{
+      RoomResultsContainer: {
         margin: margins.auto,
         width: "80%",
       },
@@ -427,6 +427,10 @@ export const createAppTheme = (currentPalette) =>
           backgroundColor: currentPalette.AllocRoom.musiikkiluokka.color,
           borderColor: currentPalette.borderColorDark.main,
         },
+      },
+      Links: {
+        textDecoration: "none",
+        color: currentPalette.fontColorDefault.default,
       },
       MuiButton: {
         styleOverrides: {

--- a/src/views/AllocationSubjectFailureView.jsx
+++ b/src/views/AllocationSubjectFailureView.jsx
@@ -1,3 +1,4 @@
+import useTheme from "@mui/material/styles/useTheme";
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ajaxRequestErrorHandler } from "../ajax/ajaxRequestErrorHandler";
@@ -48,6 +49,8 @@ export const getNameForId = (array, id) => {
 };
 
 export default function AllocationSubjectFailureView() {
+  const theme = useTheme();
+
   const { allocId } = useParams();
 
   const [unAllocableSubjects, setUnAllocableSubjects] = useState([]);
@@ -204,7 +207,10 @@ export default function AllocationSubjectFailureView() {
       <Dialog open={open} onClose={handleClose} scroll="body" maxWidth="70%">
         <DialogTitle>
           {"Suitability of the space - for lesson: "}
-          <Link to={`/subject/${unAllocSubject.id}`}>
+          <Link
+            style={theme.components.Links}
+            to={`/subject/${unAllocSubject.id}`}
+          >
             {`${unAllocSubject.id} ${unAllocSubject.name}`}
           </Link>
         </DialogTitle>
@@ -231,7 +237,10 @@ export default function AllocationSubjectFailureView() {
                 {unAllocSubjectRooms.map((row) => (
                   <TableRow key={row.id}>
                     <TableCell>
-                      <Link to={`/space/${row.id}`}>{`${row.name}`}</Link>
+                      <Link
+                        style={theme.components.Links}
+                        to={`/space/${row.id}`}
+                      >{`${row.name}`}</Link>
                     </TableCell>
 
                     <GetMissingEquipment

--- a/src/views/AllocationSubjectFailureView.jsx
+++ b/src/views/AllocationSubjectFailureView.jsx
@@ -8,6 +8,7 @@ import "../styles/AllocationFailure.css";
 
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
+import { IconButton } from "@mui/material";
 import Button from "@mui/material/Button";
 
 import Card from "@mui/material/Card";
@@ -214,6 +215,15 @@ export default function AllocationSubjectFailureView() {
             {`${unAllocSubject.id} ${unAllocSubject.name}`}
           </Link>
         </DialogTitle>
+        <IconButton
+          edge="end"
+          color="inherit"
+          onClick={() => setOpen(false)}
+          aria-label="close"
+          style={{ position: "absolute", top: "10px", right: "20px" }}
+        >
+          <CloseIcon />
+        </IconButton>
         <DialogContent>
           <TableContainer component={Paper}>
             <Table sx={{ minWidth: 650 }} aria-label="simple table">
@@ -300,13 +310,7 @@ export default function AllocationSubjectFailureView() {
           </TableContainer>
         </DialogContent>
         <DialogActions>
-          <Button
-            onClick={handleClose}
-            sx={{
-              backgroundColor: "#ff6d00",
-              cursor: "pointer",
-            }}
-          >
+          <Button onClick={handleClose} variant="contained">
             Exit
           </Button>
         </DialogActions>


### PR DESCRIPTION
Added styling to the links and exit button. Also added an exit icon button on the top for usability (no need to scroll all the way down to exit the view). 