### PR TITLE
Add confirmation dialog for editing equipment

### DIFF
--- a/src/components/equipment/EditEquipment.jsx
+++ b/src/components/equipment/EditEquipment.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import dao from "../../ajax/dao";
 import Logger from "../../logger/logger";
 import ValidateEditEquipment from "../../validation/ValidateEditEquipment";
+import { capitalizeFirstLetter } from "../../validation/ValidationUtilities";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 import EditEquipmentForm from "./EditEquipmentForm";
@@ -42,8 +43,9 @@ export default function EditEquipment({
 
   const submitEditedEquipment = async (submitValues) => {
     Logger.debug(
-      `Submitting edits for equipment: ${JSON.stringify(singleEquipment)}`,
+      `Submitting edits for equipment: ${JSON.stringify(submitValues)}`,
     );
+    submitValues.name = capitalizeFirstLetter(submitValues.name);
     const success = await dao.editEquipment(submitValues, singleEquipment.id);
     if (!success) {
       setAlertOptions({

--- a/src/components/equipment/EditEquipment.jsx
+++ b/src/components/equipment/EditEquipment.jsx
@@ -4,6 +4,7 @@ import dao from "../../ajax/dao";
 import Logger from "../../logger/logger";
 import ValidateEditEquipment from "../../validation/ValidateEditEquipment";
 import AlertBox from "../common/AlertBox";
+import ConfirmationDialog from "../common/ConfirmationDialog";
 import EditEquipmentForm from "./EditEquipmentForm";
 
 export default function EditEquipment({
@@ -15,8 +16,14 @@ export default function EditEquipment({
 
   const [alertOpen, setAlertOpen] = useState(false);
   const [alertOptions, setAlertOptions] = useState({
-    message: "This is an error alert — check it out!",
+    message: "alert message",
+    title: "alert title",
     severity: "error",
+  });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogOptions, setDialogOptions] = useState({
+    title: "this is dialog",
+    content: "Something here",
   });
 
   const formik = useFormik({
@@ -25,7 +32,11 @@ export default function EditEquipment({
     validateOnChange: true,
     validate: ValidateEditEquipment,
     onSubmit: (values) => {
-      submitEditedEquipment(values);
+      setDialogOptions({
+        title: `Are you sure you want to edit ${values.name}?`,
+        content: `Press continue to save ${values.name} new information.`,
+      });
+      setDialogOpen(true);
     },
   });
 
@@ -58,6 +69,13 @@ export default function EditEquipment({
         alertOpen={alertOpen}
         alertOptions={alertOptions}
         setAlertOpen={setAlertOpen}
+      />
+      <ConfirmationDialog
+        dialogOpen={dialogOpen}
+        dialogOptions={dialogOptions}
+        setDialogOpen={setDialogOpen}
+        submit={submitEditedEquipment}
+        submitValues={formik.values}
       />
       <EditEquipmentForm formik={formik} />
     </div>

--- a/src/validation/ValidationUtilities.ts
+++ b/src/validation/ValidationUtilities.ts
@@ -3,6 +3,11 @@
 import dao from "../ajax/dao";
 import { Equipment } from "../types";
 
+// Returns a new string with the first letter of input capitalized.
+export function capitalizeFirstLetter(input: string) {
+  return input[0].toUpperCase() + input.slice(1);
+}
+
 // Check if user enters an existing equipment name.
 // Used in equipment add validations.
 export const isDuplicatedEquipmentName = async (name: string) => {


### PR DESCRIPTION
Adds confirmation dialog for editing equipment. Capitalizes the first letter of edited equipment name as add equipment feature does this too. Also added common capitalizeFirstLetter function with TypeScript. For some reason many validation files have exact copies of the same function which I think is bad because it adds pointless code duplication.