### PR TITLE
Changed the code, so when the lesson is selected, the lesson name is …

### DIFF
--- a/src/components/space/AddSpace.jsx
+++ b/src/components/space/AddSpace.jsx
@@ -7,6 +7,7 @@ import validate from "../../validation/ValidateAddSpace";
 
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { FormHelperText } from "@mui/material";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -33,7 +34,7 @@ export default function AddSpace({ getAllSpaces }) {
     area: "",
     info: "",
     personLimit: "0",
-    buildingId: "",
+    buildingId: "401",
     buildingName: "Musiikkitalo",
     availableFrom: "",
     availableTo: "",
@@ -73,7 +74,7 @@ export default function AddSpace({ getAllSpaces }) {
         name: "",
         area: "0",
         personLimit: "0",
-        buildingId: "400",
+        buildingId: "401",
         availableFrom: "",
         availableTo: "",
         classesFrom: "",

--- a/src/components/subject/AddSubjectContainer.jsx
+++ b/src/components/subject/AddSubjectContainer.jsx
@@ -175,7 +175,7 @@ export default function AddSubjectContainer({
     setInitialSubject({
       // This is so that the entered name does not change
       // even if you select the data of an existing lesson
-      name: formik.values.name,
+      name: selected.name,
 
       groupSize: selected.groupSize,
       groupCount: selected.groupCount,

--- a/src/components/subject/AddSubjectForm.jsx
+++ b/src/components/subject/AddSubjectForm.jsx
@@ -42,13 +42,13 @@ export default function AddSubjectForm({
   return (
     <div>
       <form onSubmit={formik.handleSubmit}>
-        <Grid container spacing={2} justifyContent="flex-end">
+        <Grid container spacing={2} justifyContent="center">
           <Grid
             item
             xs={12}
-            sm={12}
-            md={6}
-            lg={3}
+            sm={10}
+            md={8}
+            lg={6}
             style={{ border: "5px solid #FDA826", padding: "10px" }}
           >
             <FormControl fullWidth>


### PR DESCRIPTION
…also filled in, and some other minor changes
Now in the lesson tab, when the the user selects a subject template, the subject name is also filled in.

Also, I noticed that in add space, if you would ignore the formik warnings and still try to add the space, the application would show an empty screen. It was fixed by importing FormHelperText (it was used in the code, but never imported). Additionally, I set the default building id to show as 401.

Lastly, I trued to make the top two lines in add lesson to look a bit better. 