### PR TITLE
fixed description inputs not triggering formik validations in edit forms

### DIFF
--- a/src/components/building/EditBuildingContainer.jsx
+++ b/src/components/building/EditBuildingContainer.jsx
@@ -29,12 +29,16 @@ export default function EditBuildingContainer({
     // enableReinitialize checks if Formik needs to reset the form
     // if the initial values change
     enableReinitialize: true,
-    initialValues: singleBuilding,
+    initialValues: {
+      ...singleBuilding,
+      description:
+        singleBuilding.description === null ? "" : singleBuilding.description,
+    },
     validate,
     onSubmit: (values) => {
       setDialogOptions({
         title: `Are you sure you want to edit ${values.name}?`,
-        content: `Press continue to save ${values.name} new information. `,
+        content: `Press continue to save ${values.name} new information.`,
       });
       setDialogOpen(true);
       return;

--- a/src/components/department/EditDepartment.jsx
+++ b/src/components/department/EditDepartment.jsx
@@ -11,6 +11,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useTheme from "@mui/material/styles/useTheme";
+import Logger from "../../logger/logger";
 import { capitalizeFirstLetter } from "../../validation/ValidationUtilities";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
@@ -36,12 +37,19 @@ export default function EditDepartment({
 
   const formik = useFormik({
     enableReinitialize: true,
-    initialValues: singleDepartment,
+    initialValues: {
+      ...singleDepartment,
+      description:
+        singleDepartment.description === null
+          ? ""
+          : singleDepartment.description,
+    },
     validateOnChange: true,
     validate,
     onSubmit: (values) => {
+      Logger.debug("edit department values:", values);
       setDialogOptions({
-        title: `Are you sure you want to add ${values.name}?`,
+        title: `Are you sure you want to edit ${values.name}?`,
         content: `Press continue to save ${values.name} new information.`,
       });
       setDialogOpen(true);
@@ -93,7 +101,7 @@ export default function EditDepartment({
       >
         Edit
       </Button>
-      <Dialog open={editOpen}>
+      <Dialog open={editOpen} onClose={() => setEditOpen(false)}>
         <form onSubmit={formik.handleSubmit}>
           <DialogTitle>Edit Department</DialogTitle>
           <DialogContent>

--- a/src/components/equipment/EditEquipment.jsx
+++ b/src/components/equipment/EditEquipment.jsx
@@ -29,7 +29,11 @@ export default function EditEquipment({
 
   const formik = useFormik({
     enableReinitialize: true,
-    initialValues: singleEquipment,
+    initialValues: {
+      ...singleEquipment,
+      description:
+        singleEquipment.description === null ? "" : singleEquipment.description,
+    },
     validateOnChange: true,
     validate: ValidateEditEquipment,
     onSubmit: (values) => {


### PR DESCRIPTION
There was an issue that description fields in edit department, building and equipment not triggering formik validations correctly if returned description from backend was null. This was fixed so it sets descriptions to empty strings if they are null.

No more error messages in console and validations for department, building and equipment edits should be fully working now.