### PR TITLE
Replaced hard-coded page sizes with itemsPerPage setting

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -7,6 +7,7 @@ export const AppContext = createContext({
   userEmail: null,
   sessionToken: null,
   roles: { admin: 0, planner: 0, statist: 0 },
+  itemsPerPage: 15,
 });
 
 export const AllocRoundContext = createContext({

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,4 +1,4 @@
-import { createContext, useState } from "react";
+import { createContext } from "react";
 
 export const AppContext = createContext({
   // allocRoundId: 10004,
@@ -7,7 +7,7 @@ export const AppContext = createContext({
   userEmail: null,
   sessionToken: null,
   roles: { admin: 0, planner: 0, statist: 0 },
-  itemsPerPage: 15,
+  settings: { itemsPerPage: 15 },
 });
 
 export const AllocRoundContext = createContext({

--- a/src/components/allocRound/AllocRoundPagination.jsx
+++ b/src/components/allocRound/AllocRoundPagination.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import Pagination from "@mui/material/Pagination";
 
@@ -10,20 +10,24 @@ export default function AllocRoundPagination({
   pageSize,
 }) {
   const count = Math.ceil(allAllocRoundsList.length / pageSize);
+  const [initialRender, setInitialRender] = useState(true);
 
   useEffect(() => {
-    if (!pagination.from) return;
-    const slicedAllocRounds = allAllocRoundsList.slice(
-      pagination.from,
-      pagination.to,
-    );
-    setPaginateAllocRounds(slicedAllocRounds);
-  }, [allAllocRoundsList]);
+    if (initialRender) {
+      setInitialRender(false);
+    } else {
+      const slicedAllocRounds = allAllocRoundsList.slice(
+        pagination.from,
+        pagination.to,
+      );
+      setPaginateAllocRounds(slicedAllocRounds);
+    }
+  }, [pagination]);
 
   const handleChange = (e, p) => {
     const from = (p - 1) * pageSize;
     const to = (p - 1) * pageSize + pageSize;
-    setPagination({ from, to });
+    setPagination({ ...pagination, from: from, to: to });
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 

--- a/src/components/allocRound/AllocRoundPagination.jsx
+++ b/src/components/allocRound/AllocRoundPagination.jsx
@@ -2,13 +2,12 @@ import { useEffect } from "react";
 
 import Pagination from "@mui/material/Pagination";
 
-const pageSize = 15;
-
 export default function AllocRoundPagination({
   pagination,
   setPagination,
   allAllocRoundsList,
   setPaginateAllocRounds,
+  pageSize,
 }) {
   const count = Math.ceil(allAllocRoundsList.length / pageSize);
 

--- a/src/components/building/BuildingListPagination.jsx
+++ b/src/components/building/BuildingListPagination.jsx
@@ -1,14 +1,12 @@
-import { useEffect } from "react";
-
 import Pagination from "@mui/material/Pagination";
-
-const pageSize = 15;
+import { useEffect } from "react";
 
 export default function BuildingPagination({
   pagination,
   setPagination,
   allBuildingsList,
   setPaginateBuildings,
+  pageSize,
 }) {
   const count = Math.ceil(allBuildingsList.length / pageSize);
 

--- a/src/components/building/BuildingListPagination.jsx
+++ b/src/components/building/BuildingListPagination.jsx
@@ -1,5 +1,5 @@
 import Pagination from "@mui/material/Pagination";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function BuildingPagination({
   pagination,
@@ -9,15 +9,19 @@ export default function BuildingPagination({
   pageSize,
 }) {
   const count = Math.ceil(allBuildingsList.length / pageSize);
+  const [initialRender, setInitialRender] = useState(true);
 
   useEffect(() => {
-    if (!pagination.from) return;
-    const slicedBuildings = allBuildingsList.slice(
-      pagination.from,
-      pagination.to,
-    );
-    setPaginateBuildings(slicedBuildings);
-  }, [pagination, allBuildingsList, setPaginateBuildings]);
+    if (initialRender) {
+      setInitialRender(false);
+    } else {
+      const slicedBuildings = allBuildingsList.slice(
+        pagination.from,
+        pagination.to,
+      );
+      setPaginateBuildings(slicedBuildings);
+    }
+  }, [pagination]);
 
   const handleChange = (e, p) => {
     const from = (p - 1) * pageSize;

--- a/src/components/department/Departments.jsx
+++ b/src/components/department/Departments.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -14,6 +14,7 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import { AppContext } from "../../AppContext";
 import AddDepartment from "./AddDepartment";
 import DepartmentListContainer from "./DepartmentListContainer";
 
@@ -25,7 +26,7 @@ export default function Departments() {
   const [departmentList, setDepartmentList] = useState([]);
 
   const [page, setPage] = useState(1);
-  const rowsPerPage = 15;
+  const rowsPerPage = useContext(AppContext).settings.itemsPerPage;
   const startIndex = (page - 1) * rowsPerPage;
   const endIndex = startIndex + rowsPerPage;
   const currentData = departmentList.slice(startIndex, endIndex);
@@ -42,7 +43,7 @@ export default function Departments() {
   });
   const [/* alertOpen, */ setAlertOpen] = useState(false);
 
-  const getAllDepartments = async function () {
+  const getAllDepartments = async () => {
     Logger.debug("getAllDepartments: fetching all departments from server.");
     const { httpStatus, data } = await dao.fetchAllDepartmentData();
     if (httpStatus !== 200) {

--- a/src/components/equipment/Equipments.jsx
+++ b/src/components/equipment/Equipments.jsx
@@ -1,5 +1,5 @@
 // The Equipment Page
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -14,6 +14,7 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import { AppContext } from "../../AppContext";
 import AddEquipment from "./AddEquipment";
 import EquipmentListContainer from "./EquipmentListContainer";
 
@@ -25,7 +26,7 @@ export default function Equipments() {
   const [equipmentList, setEquipmentList] = useState([]);
 
   const [page, setPage] = useState(1);
-  const rowsPerPage = 15;
+  const rowsPerPage = useContext(AppContext).settings.itemsPerPage;
   const startIndex = (page - 1) * rowsPerPage;
   const endIndex = startIndex + rowsPerPage;
   const currentData = equipmentList.slice(startIndex, endIndex);
@@ -42,7 +43,7 @@ export default function Equipments() {
   });
   const [/* alertOpen, */ setAlertOpen] = useState(false);
 
-  const getAllEquipments = async function () {
+  const getAllEquipments = async () => {
     Logger.debug("getAllEquipments: fetching all equipments from server.");
     const { httpStatus, data } = await dao.fetchEquipmentData();
     if (httpStatus !== 200) {
@@ -66,13 +67,13 @@ export default function Equipments() {
   }, []);
 
   useEffect(() => {
-    document.title = 'Equipment';
+    document.title = "Equipment";
   }, []);
 
   return (
     <div>
       <Container maxWidth="100%">
-        {(roles.admin === "1") && (
+        {roles.admin === "1" && (
           <AddEquipment getAllEquipments={getAllEquipments} />
         )}
         <Grid container rowSpacing={0.5}>

--- a/src/components/program/ProgramList.jsx
+++ b/src/components/program/ProgramList.jsx
@@ -13,17 +13,20 @@ import TableRow from "@mui/material/TableRow";
 import TableSortLabel from "@mui/material/TableSortLabel";
 import TextField from "@mui/material/TextField";
 import styled from "@mui/material/styles/styled";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { AppContext } from "../../AppContext";
 import SingleProgramDialog from "./SingleProgramDialog";
 
 export default function ProgramList({ getAllPrograms, allProgramsList }) {
+  const pageSize = useContext(AppContext).settings.itemsPerPage;
+
   const [openDialog, setOpenDialog] = useState(false);
   const [selectedProgram, setSelectedProgram] = useState(null);
   const [order, setOrder] = useState("asc");
   const [orderBy, setOrderBy] = useState("name");
   const [searched, setSearched] = useState("");
   const [paginatedPrograms, setPaginatedPrograms] = useState([]);
-  const [pagination, setPagination] = useState({ from: 0, to: 15 });
+  const [pagination, setPagination] = useState({ from: 0, to: pageSize });
   const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
@@ -72,7 +75,7 @@ export default function ProgramList({ getAllPrograms, allProgramsList }) {
     setOrderBy(property);
 
     // Reset pagination when sorting criteria change
-    setPagination({ from: 0, to: 15 });
+    setPagination({ from: 0, to: pageSize });
   };
 
   const handleSearch = (e) => {
@@ -80,12 +83,12 @@ export default function ProgramList({ getAllPrograms, allProgramsList }) {
     setSearched(searchText);
 
     // Reset pagination when search criteria change
-    setPagination({ from: 0, to: 15 });
+    setPagination({ from: 0, to: pageSize });
   };
 
   const handleChangePage = (e, p) => {
-    const from = (p - 1) * 15;
-    const to = (p - 1) * 15 + 15;
+    const from = (p - 1) * pageSize;
+    const to = (p - 1) * pageSize + pageSize;
     setPagination({ from, to });
     setCurrentPage(p);
   };
@@ -169,7 +172,7 @@ export default function ProgramList({ getAllPrograms, allProgramsList }) {
       </Paper>
       <div>
         <Pagination
-          count={Math.ceil(allProgramsList.length / 15)}
+          count={Math.ceil(allProgramsList.length / pageSize)}
           color="primary"
           onChange={handleChangePage}
           variant="outlined"

--- a/src/components/program/ProgramPagination.jsx
+++ b/src/components/program/ProgramPagination.jsx
@@ -2,13 +2,12 @@ import { useEffect } from "react";
 
 import Pagination from "@mui/material/Pagination";
 
-const pageSize = 15;
-
 export default function ProgramPagination({
   pagination,
   setPagination,
   allProgramsList,
   setPaginatePrograms,
+  pageSize,
 }) {
   const count = Math.ceil(allProgramsList.length / pageSize);
 

--- a/src/components/space/SpacePagination.jsx
+++ b/src/components/space/SpacePagination.jsx
@@ -1,14 +1,12 @@
-import { useEffect } from "react";
-
 import Pagination from "@mui/material/Pagination";
-
-const pageSize = 15;
+import { useEffect } from "react";
 
 export default function SpacePagination({
   pagination,
   setPagination,
   allSpacesList,
   setPaginateSpaces,
+  pageSize,
 }) {
   const count = Math.ceil(allSpacesList.length / pageSize);
 

--- a/src/components/subject/SubjectPagination.jsx
+++ b/src/components/subject/SubjectPagination.jsx
@@ -2,13 +2,12 @@ import { useEffect } from "react";
 
 import Pagination from "@mui/material/Pagination";
 
-const pageSize = 15;
-
 export default function SubjectPagination({
   pagination,
   setPagination,
   allSubjectsList,
   setPaginateSubjects,
+  pageSize,
 }) {
   const count = Math.ceil(allSubjectsList.length / pageSize);
 

--- a/src/components/user/UserPagination.jsx
+++ b/src/components/user/UserPagination.jsx
@@ -2,13 +2,12 @@ import { useEffect, useState } from "react";
 
 import Pagination from "@mui/material/Pagination";
 
-const pageSize = 15;
-
 export default function UserPagination({
   pagination,
   setPagination,
   allUsersList,
   setPaginateUsers,
+  pageSize,
 }) {
   const count = Math.ceil(allUsersList.length / pageSize);
   const [initialRender, setInitialRender] = useState(true);

--- a/src/routers/Nav.jsx
+++ b/src/routers/Nav.jsx
@@ -13,7 +13,7 @@ import Container from "@mui/material/Container";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import Toolbar from "@mui/material/Toolbar";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { BrowserRouter, NavLink, Route, Routes } from "react-router-dom";
 import { AppContext } from "../AppContext";
 import { AllocRoundContext } from "../AppContext.js";
@@ -23,6 +23,7 @@ import AlertBox from "../components/common/AlertBox.jsx";
 import ConfirmationDialog from "../components/common/ConfirmationDialog.jsx";
 import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn.js";
 import Logger from "../logger/logger";
+import { getSettings, handleSettings } from "../setting/handleSettings.js";
 import logo from "../styles/SibeliusLogo.svg";
 // The different pages/views
 import AllocRoundView from "../views/AllocRoundView";
@@ -194,6 +195,15 @@ export default function NavBar() {
   );
 
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
+
+  useEffect(() => {
+    async function getAndHandleSettings() {
+      if (sibaPages[1].isLogin) {
+        handleSettings(await getSettings(), appContext);
+      }
+    }
+    getAndHandleSettings();
+  }, []);
 
   // Called to produce the drop-down menu items
   const renderDropdownMenu = (page, variant) => {

--- a/src/routers/Nav.jsx
+++ b/src/routers/Nav.jsx
@@ -198,7 +198,7 @@ export default function NavBar() {
 
   useEffect(() => {
     async function getAndHandleSettings() {
-      if (sibaPages[1].isLogin) {
+      if (appContext.sessionToken) {
         handleSettings(await getSettings(), appContext);
       }
     }

--- a/src/routers/Nav.jsx
+++ b/src/routers/Nav.jsx
@@ -13,7 +13,7 @@ import Container from "@mui/material/Container";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import Toolbar from "@mui/material/Toolbar";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useState } from "react";
 import { BrowserRouter, NavLink, Route, Routes } from "react-router-dom";
 import { AppContext } from "../AppContext";
 import { AllocRoundContext } from "../AppContext.js";

--- a/src/setting/handleSettings.js
+++ b/src/setting/handleSettings.js
@@ -15,12 +15,13 @@ export const getSettings = async () => {
 // Handles and sets settings used in the app.
 export const handleSettings = (settings, appContext) => {
   Logger.debug("Handling settings");
+  Logger.debug(settings);
 
   const itemsPerPage = settings.find(
     (setting) => setting?.name?.toLowerCase() === "items-per-page",
   );
   if (itemsPerPage) {
-    appContext.itemsPerPage = itemsPerPage.numberValue;
+    appContext.settings.itemsPerPage = itemsPerPage.numberValue;
     Logger.debug("items-per-page setting found");
   }
 };

--- a/src/setting/handleSettings.js
+++ b/src/setting/handleSettings.js
@@ -15,7 +15,6 @@ export const getSettings = async () => {
 // Handles and sets settings used in the app.
 export const handleSettings = (settings, appContext) => {
   Logger.debug("Handling settings");
-  Logger.debug(settings);
 
   const itemsPerPage = settings.find(
     (setting) => setting?.name?.toLowerCase() === "items-per-page",

--- a/src/setting/handleSettings.js
+++ b/src/setting/handleSettings.js
@@ -1,0 +1,26 @@
+import dao from "../ajax/dao";
+import Logger from "../logger/logger";
+
+export const getSettings = async () => {
+  Logger.debug("Fetching settings");
+
+  const { httpStatus, data } = await dao.fetchSettings();
+  if (httpStatus !== 200) {
+    Logger.error(`Error fetching settings, http status code: ${httpStatus}`);
+  }
+
+  return data;
+};
+
+// Handles and sets settings used in the app.
+export const handleSettings = (settings, appContext) => {
+  Logger.debug("Handling settings");
+
+  const itemsPerPage = settings.find(
+    (setting) => setting?.name?.toLowerCase() === "items-per-page",
+  );
+  if (itemsPerPage) {
+    appContext.itemsPerPage = itemsPerPage.numberValue;
+    Logger.debug("items-per-page setting found");
+  }
+};

--- a/src/views/AllocRoundView.jsx
+++ b/src/views/AllocRoundView.jsx
@@ -5,8 +5,9 @@ import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import useTheme from "@mui/material/styles/useTheme";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { AppContext } from "../AppContext";
 import dao from "../ajax/dao";
 import AllocRoundListContainer from "../components/allocRound/AllocRoundListContainer";
 import AllocRoundPagination from "../components/allocRound/AllocRoundPagination";
@@ -14,13 +15,12 @@ import AlertBox from "../components/common/AlertBox";
 import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
 import Logger from "../logger/logger";
 
-const pageSize = 15;
-
 export default function AllocRoundView() {
   Logger.logPrefix = "AllocRoundView";
   const { roles } = useRoleLoggedIn();
   const navigate = useNavigate();
   const theme = useTheme();
+  const pageSize = useContext(AppContext).settings.itemsPerPage;
 
   const [paginateAllocRounds, setpaginateAllocRounds] = useState([]);
   const [allAllocRoundsList, setallAllocRoundsList] = useState([]);
@@ -30,7 +30,6 @@ export default function AllocRoundView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-
   const [pagination, setPagination] = useState({
     from: 0,
     to: pageSize,
@@ -52,7 +51,7 @@ export default function AllocRoundView() {
     }
     Logger.debug(`Fetched allocation rounds: ${data.length}`);
     setallAllocRoundsList(data);
-    setpaginateAllocRounds(allAllocRoundsList.slice(0, 15));
+    setpaginateAllocRounds(allAllocRoundsList.slice(0, pageSize));
   };
 
   const incrementDataModifiedCounter = () => {
@@ -70,7 +69,7 @@ export default function AllocRoundView() {
   }, [dataModifiedCounter]);
 
   useEffect(() => {
-    setpaginateAllocRounds(allAllocRoundsList.slice(0, 15));
+    setpaginateAllocRounds(allAllocRoundsList.slice(0, pageSize));
   }, [allAllocRoundsList]);
 
   return (
@@ -108,6 +107,7 @@ export default function AllocRoundView() {
                 allAllocRoundsList={allAllocRoundsList}
                 paginateAllocRounds={paginateAllocRounds}
                 setPaginateAllocRounds={setpaginateAllocRounds}
+                pageSize={pageSize}
               />
             </CardContent>
           </Card>

--- a/src/views/AllocRoundView.jsx
+++ b/src/views/AllocRoundView.jsx
@@ -51,7 +51,7 @@ export default function AllocRoundView() {
     }
     Logger.debug(`Fetched allocation rounds: ${data.length}`);
     setallAllocRoundsList(data);
-    setpaginateAllocRounds(allAllocRoundsList.slice(0, pageSize));
+    setpaginateAllocRounds(data.slice(0, pageSize));
   };
 
   const incrementDataModifiedCounter = () => {

--- a/src/views/BuildingView.jsx
+++ b/src/views/BuildingView.jsx
@@ -2,7 +2,8 @@ import { CardContent, CardHeader } from "@mui/material";
 import Card from "@mui/material/Card";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { AppContext } from "../AppContext";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -15,8 +16,6 @@ import AlertBox from "../components/common/AlertBox";
 import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
 import Logger from "../logger/logger";
 
-const pageSize = 15;
-
 export default function BuildingView() {
   const { roles } = useRoleLoggedIn();
   const [paginateBuildings, setPaginateBuildings] = useState([]);
@@ -27,13 +26,14 @@ export default function BuildingView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
+  const itemsPerPage = useContext(AppContext).settings.itemsPerPage;
 
   const [pagination, setPagination] = useState({
     from: 0,
-    to: pageSize,
+    to: itemsPerPage,
   });
 
-  const getAllBuildings = async function () {
+  const getAllBuildings = async () => {
     const { httpStatus, data } = await dao.fetchAllBuildings();
     if (httpStatus !== 200) {
       ajaxRequestErrorHandler(
@@ -54,11 +54,11 @@ export default function BuildingView() {
   }, []);
 
   useEffect(() => {
-    setPaginateBuildings(allBuildingsList.slice(0, 15));
+    setPaginateBuildings(allBuildingsList.slice(0, itemsPerPage));
   }, [allBuildingsList]);
 
   useEffect(() => {
-    document.title = 'Buildings';
+    document.title = "Buildings";
   }, []);
 
   return (
@@ -69,7 +69,7 @@ export default function BuildingView() {
         setAlertOpen={setAlertOpen}
       />
       <Container maxWidth="xl">
-        {(roles.admin === "1") && (
+        {roles.admin === "1" && (
           <AddBuildingContainer getAllBuildings={getAllBuildings} />
         )}
         <Grid container rowSpacing={1}>
@@ -87,6 +87,7 @@ export default function BuildingView() {
                 allBuildingsList={allBuildingsList}
                 paginateBuildings={paginateBuildings}
                 setPaginateBuildings={setPaginateBuildings}
+                pageSize={itemsPerPage}
               />
             </CardContent>
           </Card>

--- a/src/views/BuildingView.jsx
+++ b/src/views/BuildingView.jsx
@@ -18,6 +18,8 @@ import Logger from "../logger/logger";
 
 export default function BuildingView() {
   const { roles } = useRoleLoggedIn();
+  const pageSize = useContext(AppContext).settings.itemsPerPage;
+
   const [paginateBuildings, setPaginateBuildings] = useState([]);
   const [allBuildingsList, setAllBuildingsList] = useState([]);
   const [alertOpen, setAlertOpen] = useState(false);
@@ -26,11 +28,9 @@ export default function BuildingView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-  const itemsPerPage = useContext(AppContext).settings.itemsPerPage;
-
   const [pagination, setPagination] = useState({
     from: 0,
-    to: itemsPerPage,
+    to: pageSize,
   });
 
   const getAllBuildings = async () => {
@@ -54,7 +54,7 @@ export default function BuildingView() {
   }, []);
 
   useEffect(() => {
-    setPaginateBuildings(allBuildingsList.slice(0, itemsPerPage));
+    setPaginateBuildings(allBuildingsList.slice(0, pageSize));
   }, [allBuildingsList]);
 
   useEffect(() => {
@@ -87,7 +87,7 @@ export default function BuildingView() {
                 allBuildingsList={allBuildingsList}
                 paginateBuildings={paginateBuildings}
                 setPaginateBuildings={setPaginateBuildings}
-                pageSize={itemsPerPage}
+                pageSize={pageSize}
               />
             </CardContent>
           </Card>

--- a/src/views/LoginView.jsx
+++ b/src/views/LoginView.jsx
@@ -104,12 +104,13 @@ export default function LoginView({ handleLoginChange }) {
       setAlertOpen(true);
 
       handleLoginChange();
-      handleSettings(getSettings(), appContext);
 
       setLoginForm({
         email: "",
         password: "",
       });
+
+      handleSettings(await getSettings(), appContext);
 
       // Timeout to show popup message before navigation
       setTimeout(() => {

--- a/src/views/LoginView.jsx
+++ b/src/views/LoginView.jsx
@@ -12,6 +12,7 @@ import { AppContext } from "../AppContext";
 import dao from "../ajax/dao";
 import AlertBox from "../components/common/AlertBox";
 import Logger from "../logger/logger";
+import { getSettings, handleSettings } from "../setting/handleSettings";
 import backgroundImage from "../styles/SibeliusLogoLoginPage.svg";
 
 export const localStorageClearUserLoginAndToken = () => {
@@ -103,6 +104,7 @@ export default function LoginView({ handleLoginChange }) {
       setAlertOpen(true);
 
       handleLoginChange();
+      handleSettings(getSettings(), appContext);
 
       setLoginForm({
         email: "",

--- a/src/views/ProgramView.jsx
+++ b/src/views/ProgramView.jsx
@@ -14,19 +14,18 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import AlertBox from "../components/common/AlertBox";
 import AddProgramContainer from "../components/program/AddProgramContainer";
 import ProgramListContainer from "../components/program/ProgramListContainer";
-
-const pageSize = 15;
 
 export default function ProgramView() {
   Logger.logPrefix = "ProgramView";
   Logger.debug("ProgramView component instantiated.");
 
-  const appContext = useContext(AppContext);
   const { roles } = useRoleLoggedIn();
+  const appContext = useContext(AppContext);
+  const pageSize = appContext.settings.itemsPerPage;
+
   const [paginatePrograms, setPaginatePrograms] = useState([]);
   const [allProgramsList, setAllProgramsList] = useState([]);
   const [alertOpen, setAlertOpen] = useState(false);
@@ -35,13 +34,12 @@ export default function ProgramView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-
-  Logger.debug("Initial state set.");
-
   const [pagination, setPagination] = useState({
     from: 0,
     to: pageSize,
   });
+
+  Logger.debug("Initial state set.");
 
   const getAllPrograms = async () => {
     Logger.debug("getAllPrograms: fetching all programs from server.");

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -24,6 +24,7 @@ export default function SettingsView() {
 
   const { roles } = useRoleLoggedIn();
   const appContext = useContext(AppContext);
+  const pageSize = appContext.settings.itemsPerPage;
 
   // State for checking if Settings card is expanded
   const [isCardExpanded, setIsCardExpanded] = useState(true);
@@ -51,7 +52,7 @@ export default function SettingsView() {
     } else {
       Logger.info(`Fetched ${data.length} settings.`);
       setSettings(data);
-      setPaginateSettings(settings.slice(0, 15));
+      setPaginateSettings(settings.slice(0, pageSize));
       handleSettings(data, appContext);
     }
   };
@@ -70,7 +71,7 @@ export default function SettingsView() {
   }, [dataModifiedCounter]);
 
   useEffect(() => {
-    setPaginateSettings(settings.slice(0, 15));
+    setPaginateSettings(settings.slice(0, pageSize));
   }, [settings]);
 
   useEffect(() => {

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -1,5 +1,5 @@
 // The Settings Page
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -13,14 +13,17 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
+import { AppContext } from "../AppContext";
 import AlertBox from "../components/common/AlertBox";
 import AddSettingContainer from "../components/settings/AddSettingContainer";
 import SettingsListContainer from "../components/settings/SettingsListContainer";
+import { handleSettings } from "../setting/handleSettings";
 
 export default function SettingsView() {
   Logger.logPrefix = "SettingsView";
 
   const { roles } = useRoleLoggedIn();
+  const appContext = useContext(AppContext);
 
   // State for checking if Settings card is expanded
   const [isCardExpanded, setIsCardExpanded] = useState(true);
@@ -34,7 +37,7 @@ export default function SettingsView() {
     severity: "error",
   });
 
-  const getAllSettings = async function () {
+  const getAllSettings = async () => {
     Logger.debug("Fetching all settings");
     const { httpStatus, data } = await dao.fetchSettings();
     if (httpStatus !== 200) {
@@ -49,6 +52,7 @@ export default function SettingsView() {
       Logger.info(`Fetched ${data.length} settings.`);
       setSettings(data);
       setPaginateSettings(settings.slice(0, 15));
+      handleSettings(data, appContext);
     }
   };
 

--- a/src/views/SpaceView.jsx
+++ b/src/views/SpaceView.jsx
@@ -15,26 +15,22 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import AlertBox from "../components/common/AlertBox";
 import AddSpace from "../components/space/AddSpace";
 import SpaceFiltering from "../components/space/SpaceFiltering";
 import SpaceListContainer from "../components/space/SpaceListContainer";
 import SpacePagination from "../components/space/SpacePagination";
 
-const pageSize = 15;
-
 export default function SpaceView() {
   Logger.logPrefix = "SpaceView";
   Logger.debug("SpaceView component instantiated.");
+
   const { roles } = useRoleLoggedIn();
-
-  const itemsPerPage = useContext(AppContext).settings.itemsPerPage;
-
   let { spaceIdToShow } = useParams();
+  const pageSize = useContext(AppContext).settings.itemsPerPage;
+
   const [spaceIdToShowState, setSpaceIdToShowState] = useState(spaceIdToShow);
   const [shownSpace, setShownSpace] = useState(null);
-
   const [paginateSpaces, setPaginateSpaces] = useState([]);
   const [allSpacesList, setAllSpacesList] = useState([]);
   const [alertOpen, setAlertOpen] = useState(false);
@@ -43,17 +39,16 @@ export default function SpaceView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
+  const [pagination, setPagination] = useState({
+    from: 0,
+    to: pageSize,
+  });
+
+  Logger.debug("Initial state set.");
 
   const setShownSpace2 = (state) => {
     setShownSpace(state);
   };
-
-  Logger.debug("Initial state set.");
-
-  const [pagination, setPagination] = useState({
-    from: 0,
-    to: itemsPerPage,
-  });
 
   const getAllSpaces = async () => {
     Logger.debug("getAllSpaces: fetching all spaces from server.");
@@ -68,7 +63,7 @@ export default function SpaceView() {
     } else {
       Logger.debug(`getAllSpaces: successfully fetched ${data.length} spaces.`);
       setAllSpacesList(data);
-      setPaginateSpaces(data.slice(0, itemsPerPage));
+      setPaginateSpaces(data.slice(0, pageSize));
     }
   };
 
@@ -79,7 +74,7 @@ export default function SpaceView() {
 
   useEffect(() => {
     Logger.debug("Running effect to update paginated spaces.");
-    setPaginateSpaces(allSpacesList.slice(0, itemsPerPage));
+    setPaginateSpaces(allSpacesList.slice(0, pageSize));
   }, [allSpacesList]);
 
   useEffect(() => {
@@ -157,7 +152,7 @@ export default function SpaceView() {
                 allSpacesList={allSpacesList}
                 paginateSpaces={paginateSpaces}
                 setPaginateSpaces={setPaginateSpaces}
-                pageSize={itemsPerPage}
+                pageSize={pageSize}
               />
             </CardContent>
           </Card>

--- a/src/views/SpaceView.jsx
+++ b/src/views/SpaceView.jsx
@@ -29,7 +29,7 @@ export default function SpaceView() {
   Logger.debug("SpaceView component instantiated.");
   const { roles } = useRoleLoggedIn();
 
-  const appContext = useContext(AppContext);
+  const itemsPerPage = useContext(AppContext).settings.itemsPerPage;
 
   let { spaceIdToShow } = useParams();
   const [spaceIdToShowState, setSpaceIdToShowState] = useState(spaceIdToShow);
@@ -52,10 +52,10 @@ export default function SpaceView() {
 
   const [pagination, setPagination] = useState({
     from: 0,
-    to: pageSize,
+    to: itemsPerPage,
   });
 
-  const getAllSpaces = async function () {
+  const getAllSpaces = async () => {
     Logger.debug("getAllSpaces: fetching all spaces from server.");
     const { httpStatus, data } = await dao.fetchAllSpaces();
     if (httpStatus !== 200) {
@@ -68,7 +68,7 @@ export default function SpaceView() {
     } else {
       Logger.debug(`getAllSpaces: successfully fetched ${data.length} spaces.`);
       setAllSpacesList(data);
-      setPaginateSpaces(data.slice(0, 15));
+      setPaginateSpaces(data.slice(0, itemsPerPage));
     }
   };
 
@@ -79,7 +79,7 @@ export default function SpaceView() {
 
   useEffect(() => {
     Logger.debug("Running effect to update paginated spaces.");
-    setPaginateSpaces(allSpacesList.slice(0, 15));
+    setPaginateSpaces(allSpacesList.slice(0, itemsPerPage));
   }, [allSpacesList]);
 
   useEffect(() => {
@@ -157,6 +157,7 @@ export default function SpaceView() {
                 allSpacesList={allSpacesList}
                 paginateSpaces={paginateSpaces}
                 setPaginateSpaces={setPaginateSpaces}
+                pageSize={itemsPerPage}
               />
             </CardContent>
           </Card>

--- a/src/views/SubjectView.jsx
+++ b/src/views/SubjectView.jsx
@@ -15,20 +15,18 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import AlertBox from "../components/common/AlertBox";
 import AddSubjectContainer from "../components/subject/AddSubjectContainer";
 import SubjectFiltering from "../components/subject/SubjectFiltering";
 import SubjectListContainer from "../components/subject/SubjectListContainer";
 import SubjectPagination from "../components/subject/SubjectPagination";
 
-const pageSize = 15;
-
 export default function SubjectView() {
   Logger.logPrefix = "SubjectView";
   Logger.debug("SubjectView component instantiated.");
 
   const appContext = useContext(AppContext);
+  const pageSize = appContext.settings.itemsPerPage;
   const { roles } = useRoleLoggedIn();
   const { allocRoundContext } = useContext(AllocRoundContext);
 
@@ -46,19 +44,18 @@ export default function SubjectView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-
-  const setShownSubject2 = (stateSubject) => {
-    setShownSubject(stateSubject);
-  };
-
-  Logger.debug("Initial state set.");
-
   const [pagination, setPagination] = useState({
     from: 0,
     to: pageSize,
   });
 
-  const getAllSubjects = async function () {
+  Logger.debug("Initial state set.");
+
+  const setShownSubject2 = (stateSubject) => {
+    setShownSubject(stateSubject);
+  };
+
+  const getAllSubjects = async () => {
     Logger.debug(
       "getAllSubjects: fetching all subjects in allocRound, from server.",
     );
@@ -79,11 +76,11 @@ export default function SubjectView() {
         `getAllSubjects: successfully fetched ${data.length} subjects.`,
       );
       setAllSubjectsList(data);
-      setPaginateSubjects(data.slice(0, 15));
+      setPaginateSubjects(data.slice(0, pageSize));
     }
   };
 
-  const getUserPrograms = async function () {
+  const getUserPrograms = async () => {
     const { httpStatus, data } = await dao.getProgramsByUserId(
       appContext.userId,
     );
@@ -154,7 +151,7 @@ export default function SubjectView() {
 
   useEffect(() => {
     Logger.debug("Running effect to update paginated subjects.");
-    setPaginateSubjects(allSubjectsList.slice(0, 15));
+    setPaginateSubjects(allSubjectsList.slice(0, pageSize));
   }, [allSubjectsList]);
 
   useEffect(() => {
@@ -221,6 +218,7 @@ export default function SubjectView() {
                 allSubjectsList={allSubjectsList}
                 paginateSubjects={paginateSubjects}
                 setPaginateSubjects={setPaginateSubjects}
+                pageSize={pageSize}
               />
             </CardContent>
           </Card>

--- a/src/views/UserView.jsx
+++ b/src/views/UserView.jsx
@@ -13,7 +13,6 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import AlertBox from "../components/common/AlertBox";
 import AddUser from "../components/user/AddUser";
 import UserFiltering from "../components/user/UserFiltering";
@@ -21,14 +20,14 @@ import UserListContainer from "../components/user/UserListContainer";
 import UserPagination from "../components/user/UserPagination";
 import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
 
-const pageSize = 15;
-
 export default function UserView() {
   Logger.logPrefix = "UserView";
   Logger.debug("UserView component instantiated.");
 
   const appContext = useContext(AppContext);
+  const pageSize = appContext.settings.itemsPerPage;
   const { roles } = useRoleLoggedIn();
+
   const [paginateUsers, setPaginateUsers] = useState([]);
   const [allUsersList, setAllUsersList] = useState([]);
   const [alertOpen, setAlertOpen] = useState(false);
@@ -37,15 +36,14 @@ export default function UserView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-
-  Logger.debug("Initial state set.");
-
   const [pagination, setPagination] = useState({
     from: 0,
     to: pageSize,
   });
 
-  const getAllUsers = async function () {
+  Logger.debug("Initial state set.");
+
+  const getAllUsers = async () => {
     Logger.debug("getAllUsers: fetching all Users from server.");
     const { httpStatus, data } = await dao.fetchAllUsers();
     if (httpStatus !== 200) {
@@ -58,7 +56,7 @@ export default function UserView() {
     } else {
       Logger.debug(`getAllUsers: successfully fetched ${data.length} Users.`);
       setAllUsersList(data);
-      setPaginateUsers(data.slice(0, 15));
+      setPaginateUsers(data.slice(0, pageSize));
     }
   };
 
@@ -69,11 +67,11 @@ export default function UserView() {
 
   useEffect(() => {
     Logger.debug("Running effect to update paginated Users.");
-    setPaginateUsers(allUsersList.slice(0, 15));
+    setPaginateUsers(allUsersList.slice(0, pageSize));
   }, [allUsersList]);
 
   useEffect(() => {
-    document.title = 'User List';
+    document.title = "User List";
   }, []);
 
   return (
@@ -84,37 +82,38 @@ export default function UserView() {
         setAlertOpen={setAlertOpen}
       />
       <Container maxWidth="100%">
-          {roles.admin === "1" && (
-            <AddUser getAllUsers={getAllUsers} allUsersList={allUsersList}/> 
-          )}
-          <Grid container rowSpacing={1}>
-            <Card variant="outlined">
-              <CardContent>
-                <CardHeader title="Users" variant="pageHeader" />
-                <UserFiltering
-                  allUsersList={allUsersList}
-                  setAllUsersList={setAllUsersList}
-                  paginateUsers={paginateUsers}
-                  setPaginateUsers={setPaginateUsers}
-                  pagination={pagination}
-                />
-                <UserListContainer
-                  getAllUsers={getAllUsers}
-                  allUsersList={allUsersList}
-                  paginateUsers={paginateUsers}
-                  open={open}
-                  setOpen={setOpen}
-                />
-                <UserPagination
-                  pagination={pagination}
-                  setPagination={setPagination}
-                  allUsersList={allUsersList}
-                  paginateUsers={paginateUsers}
-                  setPaginateUsers={setPaginateUsers}
-                />
-              </CardContent>
-            </Card>
-          </Grid>
+        {roles.admin === "1" && (
+          <AddUser getAllUsers={getAllUsers} allUsersList={allUsersList} />
+        )}
+        <Grid container rowSpacing={1}>
+          <Card variant="outlined">
+            <CardContent>
+              <CardHeader title="Users" variant="pageHeader" />
+              <UserFiltering
+                allUsersList={allUsersList}
+                setAllUsersList={setAllUsersList}
+                paginateUsers={paginateUsers}
+                setPaginateUsers={setPaginateUsers}
+                pagination={pagination}
+              />
+              <UserListContainer
+                getAllUsers={getAllUsers}
+                allUsersList={allUsersList}
+                paginateUsers={paginateUsers}
+                open={open}
+                setOpen={setOpen}
+              />
+              <UserPagination
+                pagination={pagination}
+                setPagination={setPagination}
+                allUsersList={allUsersList}
+                paginateUsers={paginateUsers}
+                setPaginateUsers={setPaginateUsers}
+                pageSize={pageSize}
+              />
+            </CardContent>
+          </Card>
+        </Grid>
       </Container>
     </div>
   );


### PR DESCRIPTION
Added a way to fetch and handle settings. Pagination components used hard-coded value 15 to display items per page. This was replaced to use new items-per-page setting fetched from backend. The number of items to display per page can be changed within the application in the settings view. Settings are fetched and handled after user has logged in and when refreshing the website.

I added a settings section to AppContext.js and a common way to handle settings, so it is maybe easier to make new frontend settings in the future if needed.

Also with this change, I was able to find two new bugs in building and allocation paginations. When changing page and then trying to go back to page 1, it wouldn't render the items of page 1. These were fixed.

NOTE: Please accept the pull request about inserting the new items-per-page test data setting in the backend repository.