### PR TITLE
Excel import olli

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@ramonak/react-progress-bar": "^5.0.3",
     "axios": "^1.6.2",
     "esbuild": "^0.19.6",
+    "exceljs": "^4.4.0",
+    "file-saver": "^2.0.5",
     "formik": "^2.4.5",
     "js-file-download": "^0.4.12",
     "luxon": "^3.4.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "luxon": "^3.4.4",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
+    "react-csv": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.19.0",
     "selenium-webdriver": "^4.15.0"

--- a/src/ajax/dao_allocRound.ts
+++ b/src/ajax/dao_allocRound.ts
@@ -56,8 +56,8 @@ export const deleteSingleAllocRound = async (id: number): Promise<boolean> => {
 };
 
 //fetch all data for excel
-/*export const fetchReportData = async () : Promise<Response<any>> => {
-  const response = await get(`${baseUrl}/allocRound`);
-  const allocrounds: AllocRound[] = await response.json();
-  return { success: response.ok, data: allocrounds };
-};*/
+export const fetchReportData = async (): Promise<Response<Report>> => {
+  const response = await get(`${baseUrl}/report`);
+  const reportData: Report[] = await response.json();
+  return { success: response.ok, data: reportData };
+};

--- a/src/ajax/dao_allocRound.ts
+++ b/src/ajax/dao_allocRound.ts
@@ -54,10 +54,3 @@ export const deleteSingleAllocRound = async (id: number): Promise<boolean> => {
   const response = await remove(`${baseUrl}/allocRound/${id}`);
   return response.ok;
 };
-
-//fetch all data for excel
-export const fetchReportData = async (): Promise<Response<Report>> => {
-  const response = await get(`${baseUrl}/report`);
-  const reportData: Report[] = await response.json();
-  return { success: response.ok, data: reportData };
-};

--- a/src/ajax/dao_allocRound.ts
+++ b/src/ajax/dao_allocRound.ts
@@ -54,3 +54,10 @@ export const deleteSingleAllocRound = async (id: number): Promise<boolean> => {
   const response = await remove(`${baseUrl}/allocRound/${id}`);
   return response.ok;
 };
+
+//fetch all data for excel
+/*export const fetchReportData = async () : Promise<Response<any>> => {
+  const response = await get(`${baseUrl}/allocRound`);
+  const allocrounds: AllocRound[] = await response.json();
+  return { success: response.ok, data: allocrounds };
+};*/

--- a/src/ajax/dao_allocation.ts
+++ b/src/ajax/dao_allocation.ts
@@ -52,15 +52,21 @@ export const getMissingEquipmentForRoom = async (
 };
 
 //fetch all data for excel
-export const fetchReportData = async (): Promise<Response<Report>> => {
-  const response = await get(`${baseUrl}/allocation/report`);
+export const fetchReportData = async (
+  allocRoundId: number,
+): Promise<Response<Report>> => {
+  const response = await get(`${baseUrl}/allocation/report/${allocRoundId}`);
   const reportData: Report[] = await response.json();
   return { success: response.ok, data: reportData };
 };
 
-//fetch all data for excel
-export const fetchPlannerData = async (): Promise<Response<Report>> => {
-  const response = await get(`${baseUrl}/allocation/plannerreport`);
+//fetch planner data for excel
+export const fetchPlannerData = async (
+  allocRoundId: number,
+): Promise<Response<Report>> => {
+  const response = await get(
+    `${baseUrl}/allocation/plannerreport/${allocRoundId}`,
+  );
   const reportData: Report[] = await response.json();
   return { success: response.ok, data: reportData };
 };

--- a/src/ajax/dao_allocation.ts
+++ b/src/ajax/dao_allocation.ts
@@ -57,3 +57,10 @@ export const fetchReportData = async (): Promise<Response<Report>> => {
   const reportData: Report[] = await response.json();
   return { success: response.ok, data: reportData };
 };
+
+//fetch all data for excel
+export const fetchPlannerData = async (): Promise<Response<Report>> => {
+  const response = await get(`${baseUrl}/allocation/plannerreport`);
+  const reportData: Report[] = await response.json();
+  return { success: response.ok, data: reportData };
+};

--- a/src/ajax/dao_allocation.ts
+++ b/src/ajax/dao_allocation.ts
@@ -1,5 +1,6 @@
 import {
   MissingEquipment,
+  Response,
   ResponseFiner,
   SubjectRoom,
   UnallocableSubject,
@@ -48,4 +49,11 @@ export const getMissingEquipmentForRoom = async (
   } else {
     return { httpStatus: response.status, data: [] };
   }
+};
+
+//fetch all data for excel
+export const fetchReportData = async (): Promise<Response<Report>> => {
+  const response = await get(`${baseUrl}/allocation/report`);
+  const reportData: Report[] = await response.json();
+  return { success: response.ok, data: reportData };
 };

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -134,7 +134,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
       <Button
         type="submit"
         variant="outlined"
-        color="inherit"
+        color="secondary"
         disabled={!isClicked}
       >
         <CSVLink
@@ -142,7 +142,8 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
           data={reportData}
           filename={fileName}
           separator={";"}
-          style={{ textDecoration: "none", color: "#fff" }}
+          style={{ textDecoration: "none", color: "inherit" }}
+          disabled={!isClicked}
         >
           Download full report
         </CSVLink>
@@ -150,15 +151,15 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
       <Button
         type="submit"
         variant="outlined"
-        color="inherit"
+        color="secondary"
         disabled={!isClicked}
       >
         <CSVLink
           headers={headers}
           data={plannerData}
           filename={fileNamePlanner}
-          separator={";"}
-          style={{ textDecoration: "none", color: "#fff" }}
+          style={{ textDecoration: "none", color: "inherit" }}
+          disabled={!isClicked}
         >
           Download Planner report
         </CSVLink>

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -29,7 +29,6 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
     { header: "Program", key: "program", width: 20 },
     { header: "Lesson", key: "lesson", width: 20 },
     { header: "Room", key: "room", width: 20 },
-    { header: "Subject Id", key: "subjectId", width: 20 },
   ];
 
   const setDelayedClickedToggle = () => {
@@ -60,10 +59,6 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
     const reportsheet = report.addWorksheet("Report");
     reportsheet.columns = sheetcolumns;
 
-    /*data.forEach((row) => {
-      reportsheet.addRow(row);
-    }); */
-
     for (const row of data) {
       reportsheet.addRow(row);
     }
@@ -79,7 +74,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
 
       const blob = new Blob([buffer], { type: fileType });
 
-      saveAs(blob, `Report ${fileExtension}`);
+      saveAs(blob, `Allocated-Lessons${fileExtension}`);
       report.removeWorksheet(reportsheet.id);
     } catch (err) {
       console.log(`Could not download report: ${err}`);
@@ -104,9 +99,6 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
     const plannersheet = plannerReport.addWorksheet("Planner");
     plannersheet.columns = sheetcolumns;
 
-    /*data.forEach((row) => {
-      plannersheet.addRow(row);
-    }); */
     for (const row of data) {
       plannersheet.addRow(row);
     }
@@ -122,7 +114,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
 
       const blob = new Blob([buffer], { type: fileType });
 
-      saveAs(blob, `PlannerReport ${fileExtension}`);
+      saveAs(blob, `Your-Allocated-Lessons${fileExtension}`);
       plannerReport.removeWorksheet(plannersheet.id);
     } catch (err) {
       console.log(`Could not download report: ${err}`);

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -157,6 +157,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
           headers={headers}
           data={plannerData}
           filename={fileNamePlanner}
+          separator={";"}
           style={{ textDecoration: "none", color: "#fff" }}
         >
           Download Planner report

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -25,10 +25,10 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
   const report = new ExcelJS.Workbook();
   const plannerReport = new ExcelJS.Workbook();
   const sheetcolumns = [
-    { header: "Department", key: "department", width: 20 },
-    { header: "Program", key: "program", width: 20 },
-    { header: "Lesson", key: "lesson", width: 20 },
-    { header: "Room", key: "room", width: 20 },
+    { header: "Department", key: "department", width: 35, height: 20 },
+    { header: "Program", key: "program", width: 45, height: 20 },
+    { header: "Lesson", key: "lesson", width: 53, height: 20 },
+    { header: "Room", key: "room", width: 35, height: 20 },
   ];
 
   const setDelayedClickedToggle = () => {

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -69,6 +69,22 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
           Show failed allocation
         </Button>
       </Link>
+      <Button
+        type="submit"
+        variant="outlined"
+        color="inherit"
+        disabled={!isClicked}
+      >
+        Download full report
+      </Button>
+      <Button
+        type="submit"
+        variant="outlined"
+        color="inherit"
+        disabled={!isClicked}
+      >
+        Download Planner report
+      </Button>
     </Typography>
   );
 }

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -1,19 +1,36 @@
-import useTheme from "@mui/material/styles/useTheme";
-import { useContext, useState } from "react";
-import { AllocRoundContext } from "../../AppContext";
-import allocationPost from "../../data/ResultAllocationStore";
-
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
+import { useContext, useState } from "react";
+import { CSVLink } from "react-csv";
 import { Link } from "react-router-dom";
+import { AllocRoundContext } from "../../AppContext";
+import dao from "../../ajax/dao";
+import allocationPost from "../../data/ResultAllocationStore";
+import AlertBox from "../common/AlertBox";
 
 export default function AllocRoundControlPanel({ incrementResetCounter }) {
   const { allocRoundContext } = useContext(AllocRoundContext);
   // console.log("appContext 123: " + appContext);
 
   const theme = useTheme();
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertOptions, setAlertOptions] = useState({
+    message: "This is an error alert — check it out!",
+    severity: "error",
+  });
 
   const [isClicked, setIsClicked] = useState(true);
+  const fileName = "Allocation-Report";
+  const fileNamePlanner = "Allocation-Report-Department";
+  const [reportData, setReportData] = useState([]);
+  const [plannerData, setPlannerData] = useState([]);
+  const headers = [
+    { label: "Department", key: "department" },
+    { label: "Program", key: "program" },
+    { label: "Lesson", key: "lesson" },
+    { label: "Room", key: "room" },
+  ];
 
   const setDelayedClickedToggle = () => {
     setTimeout(() => {
@@ -26,8 +43,49 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
     }, 3000);
   };
 
+  const getReportData = async () => {
+    const { success, data } = await dao.fetchReportData();
+    console.log(success);
+    if (!success) {
+      setAlertOptions({
+        severity: "error",
+        title: "Error",
+        message:
+          "Something went wrong with report data - please try again later.",
+      });
+
+      return;
+    }
+
+    setReportData(data);
+    console.log(data);
+  };
+
+  const getPlannerData = async () => {
+    const { success, data } = await dao.fetchPlannerData();
+    console.log(success);
+    if (!success) {
+      setAlertOptions({
+        severity: "error",
+        title: "Error",
+        message:
+          "Something went wrong with report data - please try again later.",
+      });
+
+      return;
+    }
+
+    setPlannerData(data);
+    console.log(data);
+  };
+
   return (
     <Typography component="p" variant="allocRoundControlPanel">
+      <AlertBox
+        alertOpen={alertOpen}
+        alertOptions={alertOptions}
+        setAlertOpen={setAlertOpen}
+      />
       Allocation {allocRoundContext.allocRoundId}&nbsp;:&nbsp;
       {allocRoundContext.allocRoundName} &nbsp; - &nbsp;After 'Start' or 'Reset'
       wait for a few seconds
@@ -39,6 +97,8 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
         onClick={() => {
           allocationPost.startAlloc(allocRoundContext.allocRoundId);
           setDelayedClickedToggle();
+          getReportData();
+          getPlannerData();
         }}
         disabled={isClicked}
       >
@@ -51,6 +111,8 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
         onClick={() => {
           allocationPost.resetAlloc(allocRoundContext.allocRoundId);
           setDelayedClickedToggle();
+          getReportData();
+          getPlannerData();
         }}
         disabled={!isClicked}
       >
@@ -75,7 +137,15 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
         color="inherit"
         disabled={!isClicked}
       >
-        Download full report
+        <CSVLink
+          headers={headers}
+          data={reportData}
+          filename={fileName}
+          separator={";"}
+          style={{ textDecoration: "none", color: "#fff" }}
+        >
+          Download full report
+        </CSVLink>
       </Button>
       <Button
         type="submit"
@@ -83,7 +153,14 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
         color="inherit"
         disabled={!isClicked}
       >
-        Download Planner report
+        <CSVLink
+          headers={headers}
+          data={plannerData}
+          filename={fileNamePlanner}
+          style={{ textDecoration: "none", color: "#fff" }}
+        >
+          Download Planner report
+        </CSVLink>
       </Button>
     </Typography>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,6 +91,13 @@ export interface CopyAllocRound {
   name: string;
 }
 
+export interface Report {
+  department: string;
+  program: string;
+  lesson: string;
+  room: string;
+}
+
 export interface Building {
   id: number;
   name: string;


### PR DESCRIPTION
Has buttons for downloading excel when allocation has been done. Downloaded excel is easier to read than csv, but not perfect yet. Was also wondering if the reports should be moved to their own component. Requires the backend branch [excel-import-changes-olli](https://github.com/haagahelia/Siba_be/tree/excel-import-changes-olli) and npm update, since had to install excelJS and filesaver.