### PR TITLE
CollapsedRowB shows h after the hours

### DIFF
--- a/src/components/result/CollapsedRowB.jsx
+++ b/src/components/result/CollapsedRowB.jsx
@@ -79,7 +79,7 @@ export default function CollapsedRowB({ id }) {
                     marginTop: margins.small,
                   }}
                 >
-                  {subject.totalTime}
+                  {subject.totalTime} h
                 </Typography>
               </Grid2>
             </Grid2>


### PR DESCRIPTION
This is a silly add, but it makes roomResults and programResults look more similar. roomResults used to get totalHours in the format 6:00:00, now gets it as hours and I just wanted to add the h after it. Requires the backend pull request [services-to-knex](https://github.com/haagahelia/Siba_be/pull/329) to make sense.