### PR TITLE
Changed SpaceType to use itemsPerPage setting and added pagination for settings

### DIFF
--- a/src/components/allocRound/AllocRoundPagination.jsx
+++ b/src/components/allocRound/AllocRoundPagination.jsx
@@ -27,7 +27,7 @@ export default function AllocRoundPagination({
   const handleChange = (e, p) => {
     const from = (p - 1) * pageSize;
     const to = (p - 1) * pageSize + pageSize;
-    setPagination({ ...pagination, from: from, to: to });
+    setPagination({ from, to });
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 

--- a/src/components/settings/SettingsPagination.jsx
+++ b/src/components/settings/SettingsPagination.jsx
@@ -6,6 +6,7 @@ export default function SettingsPagination({
   pagination,
   setPagination,
   allSettingsList,
+  paginateSettings,
   setPaginateSettings,
   pageSize,
 }) {
@@ -22,7 +23,7 @@ export default function SettingsPagination({
       );
       setPaginateSettings(slicedSettings);
     }
-  }, [pagination]);
+  }, [pagination, paginateSettings]);
 
   const handleChange = (e, p) => {
     const from = (p - 1) * pageSize;

--- a/src/components/settings/SettingsPagination.jsx
+++ b/src/components/settings/SettingsPagination.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+import Pagination from "@mui/material/Pagination";
+
+export default function SettingsPagination({
+  pagination,
+  setPagination,
+  allSettingsList,
+  setPaginateSettings,
+  pageSize,
+}) {
+  const count = Math.ceil(allSettingsList.length / pageSize);
+  const [initialRender, setInitialRender] = useState(true);
+
+  useEffect(() => {
+    if (initialRender) {
+      setInitialRender(false);
+    } else {
+      const slicedSettings = allSettingsList.slice(
+        pagination.from,
+        pagination.to,
+      );
+      setPaginateSettings(slicedSettings);
+    }
+  }, [pagination]);
+
+  const handleChange = (e, p) => {
+    const from = (p - 1) * pageSize;
+    const to = (p - 1) * pageSize + pageSize;
+    setPagination({ ...pagination, from: from, to: to });
+  };
+
+  return (
+    <Pagination count={count} onChange={handleChange} variant="outlined" />
+  );
+}

--- a/src/components/spaceType/SpaceTypeListPagination.jsx
+++ b/src/components/spaceType/SpaceTypeListPagination.jsx
@@ -1,25 +1,28 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import Pagination from "@mui/material/Pagination";
-
-const pageSize = 15;
 
 export default function SpaceTypePagination({
   pagination,
   setPagination,
   allSpaceTypesList,
   setPaginateSpaceTypes,
+  pageSize,
 }) {
   const count = Math.ceil(allSpaceTypesList.length / pageSize);
+  const [initialRender, setInitialRender] = useState(true);
 
   useEffect(() => {
-    if (!pagination.from) return;
-    const slicedSpaceTypes = allSpaceTypesList.slice(
-      pagination.from,
-      pagination.to,
-    );
-    setPaginateSpaceTypes(slicedSpaceTypes);
-  }, [pagination, allSpaceTypesList, setPaginateSpaceTypes]);
+    if (initialRender) {
+      setInitialRender(false);
+    } else {
+      const slicedSpaceTypes = allSpaceTypesList.slice(
+        pagination.from,
+        pagination.to,
+      );
+      setPaginateSpaceTypes(slicedSpaceTypes);
+    }
+  }, [pagination, allSpaceTypesList]);
 
   const handleChange = (e, p) => {
     const from = (p - 1) * pageSize;

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -17,6 +17,7 @@ import { AppContext } from "../AppContext";
 import AlertBox from "../components/common/AlertBox";
 import AddSettingContainer from "../components/settings/AddSettingContainer";
 import SettingsListContainer from "../components/settings/SettingsListContainer";
+import SettingsPagination from "../components/settings/SettingsPagination";
 import { handleSettings } from "../setting/handleSettings";
 
 export default function SettingsView() {
@@ -36,6 +37,10 @@ export default function SettingsView() {
   const [alertOptions, setAlertOptions] = useState({
     message: "This is an error alert — check it out!",
     severity: "error",
+  });
+  const [pagination, setPagination] = useState({
+    from: 0,
+    to: pageSize,
   });
 
   const getAllSettings = async () => {
@@ -98,12 +103,22 @@ export default function SettingsView() {
                 variant="pageHeader"
               />
               {isCardExpanded && (
-                <SettingsListContainer
-                  getAllSettings={getAllSettings}
-                  incrementDataModifiedCounter={incrementDataModifiedCounter}
-                  allSettings={settings}
-                  paginateSettings={paginateSettings}
-                />
+                <>
+                  <SettingsListContainer
+                    getAllSettings={getAllSettings}
+                    incrementDataModifiedCounter={incrementDataModifiedCounter}
+                    allSettings={settings}
+                    paginateSettings={paginateSettings}
+                  />
+                  <SettingsPagination
+                    pagination={pagination}
+                    setPagination={setPagination}
+                    allSettingsList={settings}
+                    paginateSettings={paginateSettings}
+                    setPaginateSettings={setPaginateSettings}
+                    pageSize={pageSize}
+                  />
+                </>
               )}
             </CardContent>
           </Card>

--- a/src/views/SpaceTypeView.jsx
+++ b/src/views/SpaceTypeView.jsx
@@ -2,7 +2,8 @@ import { CardContent, CardHeader } from "@mui/material";
 import Card from "@mui/material/Card";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { AppContext } from "../AppContext";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -15,10 +16,10 @@ import SpaceTypePagination from "../components/spaceType/SpaceTypeListPagination
 import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
 import Logger from "../logger/logger";
 
-const pageSize = 15;
-
 export default function SpaceTypeView() {
   const { roles } = useRoleLoggedIn();
+  const pageSize = useContext(AppContext).settings.itemsPerPage;
+
   const [paginateSpaceTypes, setPaginateSpaceTypes] = useState([]);
   const [allSpaceTypesList, setAllSpaceTypesList] = useState([]);
   const [alertOpen, setAlertOpen] = useState(false);
@@ -27,7 +28,6 @@ export default function SpaceTypeView() {
     message: "This is an error alert — check it out!",
     severity: "error",
   });
-
   const [pagination, setPagination] = useState({
     from: 0,
     to: pageSize,
@@ -54,7 +54,7 @@ export default function SpaceTypeView() {
   }, []);
 
   useEffect(() => {
-    setPaginateSpaceTypes(allSpaceTypesList.slice(0, 15));
+    setPaginateSpaceTypes(allSpaceTypesList.slice(0, pageSize));
   }, [allSpaceTypesList]);
 
   useEffect(() => {
@@ -87,6 +87,7 @@ export default function SpaceTypeView() {
                 allSpaceTypesList={allSpaceTypesList}
                 paginateSpaceTypes={paginateSpaceTypes}
                 setPaginateSpaceTypes={setPaginateSpaceTypes}
+                pageSize={pageSize}
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
Changed SpaceType to use the new itemsPerPage setting instead of hard-coded value 15. 

Also added pagination for the settings view. If itemsPerPage is set to 1 for example, the user can only see the first setting even though there would be more. So this fixed that issue.