### PR TITLE
hardcoded colors of buttons 

### DIFF
--- a/src/components/allocRound/AddAllocRoundForm.jsx
+++ b/src/components/allocRound/AddAllocRoundForm.jsx
@@ -1,6 +1,5 @@
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
-import useTheme from "@mui/material/styles/useTheme";
 import AllocRoundInputFields from "./AllocRoundInputFields";
 
 export default function AddAllocRoundForm({
@@ -8,8 +7,6 @@ export default function AddAllocRoundForm({
   submitValues,
   setInitialAllocRound,
 }) {
-  const theme = useTheme();
-
   const onCancel = () => {
     window.history.back(); // Return to the previous page
   };
@@ -24,7 +21,7 @@ export default function AddAllocRoundForm({
           <Button
             type="button"
             variant="outlined"
-            style={theme.components.MuiButton.redbuttton}
+            className="redButton"
             onClick={onCancel}
           >
             Cancel
@@ -32,7 +29,7 @@ export default function AddAllocRoundForm({
           <Button
             type="submit"
             variant="contained"
-            style={theme.components.MuiButton.greenbutton}
+            className="greenButton"
             onClick={() => {
               setInitialAllocRound(submitValues);
             }}

--- a/src/components/allocRound/AllocRoundControlPanel.jsx
+++ b/src/components/allocRound/AllocRoundControlPanel.jsx
@@ -1,6 +1,5 @@
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-import useTheme from "@mui/material/styles/useTheme";
 import { saveAs } from "file-saver";
 import { useContext, useState } from "react";
 import { Link } from "react-router-dom";
@@ -14,7 +13,6 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
   const { allocRoundContext } = useContext(AllocRoundContext);
   // console.log("appContext 123: " + appContext);
 
-  const theme = useTheme();
   const [alertOpen, setAlertOpen] = useState(false);
   const [alertOptions, setAlertOptions] = useState({
     message: "This is an error alert — check it out!",
@@ -66,7 +64,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
       <Button
         type="submit"
         variant="contained"
-        color="red"
+        className={`redButton ${!isClicked ? "disabledButton" : ""}`}
         onClick={() => {
           allocationPost.resetAlloc(allocRoundContext.allocRoundId);
           setDelayedClickedToggle();
@@ -82,7 +80,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
         <Button
           type="submit"
           variant="outlined"
-          color="secondary"
+          className="secondaryButton"
           disabled={!isClicked}
         >
           Show failed allocation
@@ -91,7 +89,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
       <Button
         type="submit"
         variant="outlined"
-        color="secondary"
+        className="secondaryButton"
         disabled={!isClicked}
         onClick={() => {
           getReportData(
@@ -108,7 +106,7 @@ export default function AllocRoundControlPanel({ incrementResetCounter }) {
       <Button
         type="submit"
         variant="outlined"
-        color="secondary"
+        className="secondaryButton"
         disabled={!isClicked}
         onClick={() => {
           getPlannerData(

--- a/src/components/allocRound/CopyAllocRoundContainer.jsx
+++ b/src/components/allocRound/CopyAllocRoundContainer.jsx
@@ -1,6 +1,5 @@
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
-import useTheme from "@mui/material/styles/useTheme";
 import CopyAllocRoundForm from "./CopyAllocRoundForm";
 
 export default function CopyAllocRoundContainer({
@@ -10,8 +9,6 @@ export default function CopyAllocRoundContainer({
   allAllocRoundsList,
   handleCopyAllocRoundSubmit,
 }) {
-  const theme = useTheme();
-
   const onCancel = () => {
     window.history.back(); // Return to the previous page
   };
@@ -29,7 +26,7 @@ export default function CopyAllocRoundContainer({
           <Button
             type="button"
             variant="outlined"
-            style={theme.components.MuiButton.redbuttton}
+            className="redButton"
             onClick={onCancel}
           >
             Cancel
@@ -37,7 +34,7 @@ export default function CopyAllocRoundContainer({
           <Button
             type="submit"
             variant="contained"
-            style={theme.components.MuiButton.greenbutton}
+            className="greenButton"
             onClick={() => {
               setInitialAllocRound(submitValues);
             }}

--- a/src/components/allocRound/DeleteAllocRound.jsx
+++ b/src/components/allocRound/DeleteAllocRound.jsx
@@ -1,4 +1,3 @@
-import useTheme from "@mui/material/styles/useTheme";
 import { useContext, useState } from "react";
 import { AllocRoundContext } from "../../AppContext";
 import dao from "../../ajax/dao";
@@ -13,7 +12,6 @@ export default function DeleteAllocRound({
   incrementDataModifiedCounter,
 }) {
   const { allocRoundContext } = useContext(AllocRoundContext);
-  const theme = useTheme();
 
   const [alertOpen, setAlertOpen] = useState(false);
   const [alertOptions, setAlertOptions] = useState({
@@ -86,9 +84,8 @@ export default function DeleteAllocRound({
         submitValues={deleteId}
       />
       <Button
-        // theme button red
         variant="contained"
-        style={theme.components.MuiButton.redbutton}
+        className="redButton"
         onClick={() => submitDelete(singleAllocRound)}
       >
         Delete

--- a/src/components/allocRound/EditAllocRoundForm.jsx
+++ b/src/components/allocRound/EditAllocRoundForm.jsx
@@ -1,4 +1,3 @@
-import useTheme from "@mui/material/styles/useTheme";
 import { useState } from "react";
 
 import Button from "@mui/material/Button";
@@ -10,15 +9,13 @@ import Grid from "@mui/material/Grid";
 import AllocRoundInputFields from "./AllocRoundInputFields";
 
 export default function EditAllocRoundForm({ formik }) {
-  const theme = useTheme();
-
   const [open, setOpen] = useState(false);
 
   return (
     <div>
       <Button // theme button yellow
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setOpen(true);
         }}
@@ -51,14 +48,14 @@ export default function EditAllocRoundForm({ formik }) {
                 formik.resetForm();
               }}
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
             >
               Cancel
             </Button>
             <Button // theme button green
               type="submit"
               variant="contained"
-              style={theme.components.MuiButton.greenbutton}
+              className="greenButton"
               onClick={() => {
                 setOpen(false);
               }}

--- a/src/components/allocRound/SelectAllocRound.jsx
+++ b/src/components/allocRound/SelectAllocRound.jsx
@@ -1,16 +1,15 @@
-import useTheme from "@mui/material/styles/useTheme";
 import { useContext, useState } from "react";
 import { AppContext } from "../../AppContext";
-import {AllocRoundContext} from "../../AppContext.js";
+import { AllocRoundContext } from "../../AppContext.js";
 
 import Button from "@mui/material/Button";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 
 export default function SelectAllocRound({ singleAllocRound }) {
-  const {allocRoundContext, setAllocRoundContext} = useContext(AllocRoundContext);
+  const { allocRoundContext, setAllocRoundContext } =
+    useContext(AllocRoundContext);
   const appContext = useContext(AppContext);
-  const theme = useTheme();
 
   const [alertOpen, setAlertOpen] = useState(false);
   const [alertOptions, setAlertOptions] = useState({
@@ -29,7 +28,10 @@ export default function SelectAllocRound({ singleAllocRound }) {
     // appContext.allocRoundName = allocRoundObj.name; // Now using AllocRoundContext
     localStorage.setItem("allocRoundId", allocRoundObj.id);
     localStorage.setItem("allocRoundName", allocRoundObj.name);
-    setAllocRoundContext({allocRoundId: allocRoundObj.id, allocRoundName: allocRoundObj.name});
+    setAllocRoundContext({
+      allocRoundId: allocRoundObj.id,
+      allocRoundName: allocRoundObj.name,
+    });
   };
 
   const allocationSelection = () => {
@@ -68,7 +70,7 @@ export default function SelectAllocRound({ singleAllocRound }) {
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.greenbutton}
+        className="greenButton"
         onClick={confirmAllocationSelection}
       >
         Pick this allocation

--- a/src/components/department/AddDepartmentDialogConfirmation.jsx
+++ b/src/components/department/AddDepartmentDialogConfirmation.jsx
@@ -115,7 +115,6 @@ export default function AddDepartmentDialogConfirmation({
           </Button>
           <Button
             variant="contained"
-            color="primary"
             onClick={() => {
               Logger.debug("parola italiana");
               setOpen(false);

--- a/src/components/department/EditDepartment.jsx
+++ b/src/components/department/EditDepartment.jsx
@@ -10,7 +10,6 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
-import useTheme from "@mui/material/styles/useTheme";
 import Logger from "../../logger/logger";
 import { capitalizeFirstLetter } from "../../validation/ValidationUtilities";
 import AlertBox from "../common/AlertBox";
@@ -32,8 +31,6 @@ export default function EditDepartment({
     title: "this is dialog",
     content: "Something here",
   });
-
-  const theme = useTheme();
 
   const formik = useFormik({
     enableReinitialize: true,
@@ -94,7 +91,7 @@ export default function EditDepartment({
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setEditOpen(true);
         }}

--- a/src/components/equipment/EditEquipmentForm.jsx
+++ b/src/components/equipment/EditEquipmentForm.jsx
@@ -5,18 +5,16 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
-import useTheme from "@mui/material/styles/useTheme";
 import { useState } from "react";
 
 export default function EditEquipmentForm({ formik }) {
   const [editOpen, setEditOpen] = useState(false);
-  const theme = useTheme();
 
   return (
     <>
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => setEditOpen(true)}
       >
         Edit

--- a/src/components/program/EditProgram.jsx
+++ b/src/components/program/EditProgram.jsx
@@ -17,7 +17,6 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
-import useTheme from "@mui/material/styles/useTheme";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 
@@ -43,7 +42,6 @@ export default function EditProgram({
   const [departmentSelectList, setDepartmentSelectList] = useState([]);
 
   const { roles } = useRoleLoggedIn();
-  const theme = useTheme();
 
   const getDepartmentForSelect = async () => {
     try {
@@ -140,7 +138,7 @@ export default function EditProgram({
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setEditOpen(true);
         }}

--- a/src/components/program/SingleProgramDialog.jsx
+++ b/src/components/program/SingleProgramDialog.jsx
@@ -86,7 +86,6 @@ export default function SingleProgramDialog({
       <DialogTitle id="dialog-title">{`Program: ${singleProgram?.name}`}</DialogTitle>
       <IconButton
         edge="end"
-        //color="inherit"
         onClick={() => setOpen(false)}
         aria-label="close"
         style={{ position: "absolute", top: "10px", right: "20px" }}

--- a/src/components/space/AddSpaceEquipForm.jsx
+++ b/src/components/space/AddSpaceEquipForm.jsx
@@ -12,7 +12,6 @@ import Grid from "@mui/material/Grid";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import useTheme from "@mui/material/styles/useTheme";
 
 export default function AddSpaceEquipForm({
   equipmentSelectList,
@@ -20,8 +19,6 @@ export default function AddSpaceEquipForm({
   formik,
 }) {
   const [open, setOpen] = useState(false);
-
-  const theme = useTheme();
 
   return (
     <div>
@@ -78,7 +75,7 @@ export default function AddSpaceEquipForm({
           <DialogActions>
             <Button
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
               onClick={() => {
                 setOpen(false);
                 setEquipPriority(0);

--- a/src/components/space/DeleteSpace.jsx
+++ b/src/components/space/DeleteSpace.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import dao from "../../ajax/dao";
 
 import Button from "@mui/material/Button";
-import useTheme from "@mui/material/styles/useTheme";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 
@@ -18,8 +17,6 @@ export default function DeleteSpace({ singleSpace, getAllSpaces, setOpen }) {
     content: "Something here",
   });
   const [deleteSpaceData, setDeleteSpaceData] = useState(null);
-
-  const theme = useTheme();
 
   const deleteSpace = async (spaceData) => {
     const result = await dao.deleteSingleSpace(spaceData.id);
@@ -72,7 +69,7 @@ export default function DeleteSpace({ singleSpace, getAllSpaces, setOpen }) {
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.redbutton}
+        className="redButton"
         onClick={() => submitDelete(singleSpace)}
       >
         Delete

--- a/src/components/space/DeleteSpaceEquip.jsx
+++ b/src/components/space/DeleteSpaceEquip.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import dao from "../../ajax/dao";
 
 import Button from "@mui/material/Button";
-import useTheme from "@mui/material/styles/useTheme";
 import Logger from "../../logger/logger";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 
@@ -23,8 +22,6 @@ export default function DeleteSpaceEquip({
   });
 
   const equipmentName = singleSpaceEquipToDelete.name;
-
-  const theme = useTheme();
 
   const deleteSpaceEquipment = async (submitValues = null) => {
     // We will not use submitValues
@@ -71,7 +68,7 @@ export default function DeleteSpaceEquip({
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.redbutton}
+        className="redButton"
         sx={{ maxWidth: "85px" }}
         onClick={() => {
           submitDelete(singleSpaceEquipToDelete);

--- a/src/components/space/EditSpaceForm.jsx
+++ b/src/components/space/EditSpaceForm.jsx
@@ -13,7 +13,6 @@ import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
-import useTheme from "@mui/material/styles/useTheme";
 
 export default function EditSpaceForm({
   buildingSelectList,
@@ -22,13 +21,11 @@ export default function EditSpaceForm({
 }) {
   const [open, setOpen] = useState(false);
 
-  const theme = useTheme();
-
   return (
     <div>
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setOpen(true);
         }}
@@ -265,7 +262,7 @@ export default function EditSpaceForm({
                 formik.resetForm();
               }}
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
             >
               Cancel
             </Button>

--- a/src/components/spaceType/DeleteSpaceType.jsx
+++ b/src/components/spaceType/DeleteSpaceType.jsx
@@ -1,6 +1,5 @@
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
-import useTheme from "@mui/material/styles/useTheme";
 import { useEffect, useState } from "react";
 import dao from "../../ajax/dao";
 import AlertBox from "../common/AlertBox";
@@ -11,7 +10,6 @@ export default function DeleteSpaceType({
   getAllSpaceTypes,
   setOpen,
 }) {
-  const theme = useTheme();
   const [alertOpen, setAlertOpen] = useState(false);
   const [alertOptions, setAlertOptions] = useState({
     message: "",
@@ -93,7 +91,7 @@ export default function DeleteSpaceType({
       {!hasAssociatedSpaces ? (
         <Button
           variant="contained"
-          style={theme.components.MuiButton.redbutton}
+          className="redButton"
           onClick={() => submitDelete(singleSpaceType)}
         >
           Delete
@@ -109,7 +107,7 @@ export default function DeleteSpaceType({
             <Button
               variant="contained"
               disabled
-              style={{ ...theme.components.MuiButton.redbutton, opacity: 0.5 }}
+              className="redButton disabledButton"
             >
               {`This space type has ${totalSpaceCount} space(s)`}
             </Button>

--- a/src/components/subject/AddSubEquipForm.jsx
+++ b/src/components/subject/AddSubEquipForm.jsx
@@ -18,7 +18,6 @@ import RadioGroup from "@mui/material/RadioGroup";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import useTheme from "@mui/material/styles/useTheme";
 
 export default function AddSubEquipForm({
   equipmentSelectList,
@@ -27,8 +26,6 @@ export default function AddSubEquipForm({
 }) {
   const [open, setOpen] = useState(false);
   const [equipPriority, setEquipPriority] = useState(0);
-
-  const theme = useTheme();
 
   /* Here we look for the priority of the equipment selected in select,
      so that the user can see what the equipment's default priority value is */
@@ -144,7 +141,7 @@ export default function AddSubEquipForm({
           <DialogActions>
             <Button
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
               onClick={() => {
                 setOpen(false);
                 setEquipPriority(0);

--- a/src/components/subject/DeleteSubEquip.jsx
+++ b/src/components/subject/DeleteSubEquip.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import dao from "../../ajax/dao";
 
 import Button from "@mui/material/Button";
-import useTheme from "@mui/material/styles/useTheme";
 import Logger from "../../logger/logger";
 import { margins } from "../../styles/theme";
 import ConfirmationDialog from "../common/ConfirmationDialog";
@@ -24,8 +23,6 @@ export default function DeleteSubEquip({
   });
 
   const equipmentName = singleSubEquipToDelete.name;
-
-  const theme = useTheme();
 
   const deleteSubjectEquipment = async (submitValues = null) => {
     // We will not use submitValues
@@ -75,7 +72,7 @@ export default function DeleteSubEquip({
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.redbutton}
+        className="redButton"
         sx={{ marginLeft: margins.small, maxWidth: "85px" }}
         onClick={() => {
           submitDelete(singleSubEquipToDelete);

--- a/src/components/subject/DeleteSubject.jsx
+++ b/src/components/subject/DeleteSubject.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import dao from "../../ajax/dao";
 
 import Button from "@mui/material/Button";
-import useTheme from "@mui/material/styles/useTheme";
 import AlertBox from "../common/AlertBox";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 
@@ -22,8 +21,6 @@ export default function DeleteSubject({
     content: "Something here",
   });
   const [deleteSubjectData, setDeleteSubjectData] = useState(null);
-
-  const theme = useTheme();
 
   const deleteSubject = async (subjectData) => {
     const result = await dao.deleteSingleSubject(subjectData.id);
@@ -77,7 +74,7 @@ export default function DeleteSubject({
       />
       <Button
         variant="contained"
-        style={theme.components.MuiButton.redbutton}
+        className="redButton"
         onClick={() => submitDelete(singleSubject)}
       >
         Delete

--- a/src/components/subject/EditSubEquipForm.jsx
+++ b/src/components/subject/EditSubEquipForm.jsx
@@ -14,12 +14,10 @@ import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import useTheme from "@mui/material/styles/useTheme";
 
 export default function EditSubEquipForm({ formik, priorityList }) {
   const [open, setOpen] = useState(false);
   const [equipPriority, setEquipPriority] = useState(0);
-  const theme = useTheme();
 
   /* Here we look for the priority of the equipment selected in select,
      so that the user can see what the equipment's default priority value is */
@@ -37,8 +35,8 @@ export default function EditSubEquipForm({ formik, priorityList }) {
     <div>
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
-        sx={{ maxWidth: "85px"}}
+        className="editButton"
+        sx={{ maxWidth: "85px" }}
         onClick={() => {
           setOpen(true);
         }}
@@ -106,7 +104,7 @@ export default function EditSubEquipForm({ formik, priorityList }) {
           <DialogActions>
             <Button
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
               onClick={() => {
                 setOpen(false);
                 // Let's reset the form if you press cancel

--- a/src/components/subject/EditSubjectForm.jsx
+++ b/src/components/subject/EditSubjectForm.jsx
@@ -13,7 +13,6 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
-import useTheme from "@mui/material/styles/useTheme";
 
 export default function EditSubjectForm({
   programSelectList,
@@ -22,13 +21,11 @@ export default function EditSubjectForm({
 }) {
   const [open, setOpen] = useState(false);
 
-  const theme = useTheme();
-
   return (
     <div>
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setOpen(true);
         }}
@@ -216,7 +213,7 @@ export default function EditSubjectForm({
                 formik.resetForm();
               }}
               variant="contained"
-              style={theme.components.MuiButton.redbutton}
+              className="redButton"
             >
               Cancel
             </Button>

--- a/src/components/user/EditUserForm.jsx
+++ b/src/components/user/EditUserForm.jsx
@@ -8,18 +8,16 @@ import DialogTitle from "@mui/material/DialogTitle";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import Grid from "@mui/material/Grid";
-import useTheme from "@mui/material/styles/useTheme";
 import { useState } from "react";
 
 export default function EditUserForm({ formik }) {
   const [open, setOpen] = useState(false);
-  const theme = useTheme();
 
   return (
     <div>
       <Button
         variant="contained"
-        style={theme.components.MuiButton.editbutton}
+        className="editButton"
         onClick={() => {
           setOpen(true);
         }}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -444,26 +444,24 @@ export const createAppTheme = (currentPalette) =>
               backgroundColor: currentPalette.edit.main,
               color: currentPalette.edit.contrastText,
             },
+            "&.greenButton": {
+              backgroundColor: currentPalette.success.main,
+              color: currentPalette.success.contrastText,
+            },
             "&.disabledButton": {
               opacity: 0.5,
+            },
+          },
+          outlined: {
+            "&.redButton": {
+              borderColor: currentPalette.warning.main,
+              color: currentPalette.warning.main,
             },
           },
           text: {
             backgroundColor: currentPalette.primary.main,
             color: currentPalette.primary.contrastText,
           },
-        },
-        redbutton: {
-          backgroundColor: currentPalette.warning.main,
-          color: currentPalette.warning.contrastText,
-        },
-        editbutton: {
-          backgroundColor: currentPalette.edit.main,
-          color: currentPalette.edit.contrastText,
-        },
-        greenbutton: {
-          backgroundColor: currentPalette.success.main,
-          color: currentPalette.success.contrastText,
         },
         variants: [
           {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -457,6 +457,14 @@ export const createAppTheme = (currentPalette) =>
               borderColor: currentPalette.warning.main,
               color: currentPalette.warning.main,
             },
+            "&.secondaryButton": {
+              borderColor: currentPalette.secondary.main,
+              color: currentPalette.secondary.main,
+              "&:hover": {
+                backgroundColor: currentPalette.backgroundDarker.default,
+                opacity: 0.8,
+              },
+            },
           },
           text: {
             backgroundColor: currentPalette.primary.main,

--- a/src/views/AllocRoundView.jsx
+++ b/src/views/AllocRoundView.jsx
@@ -4,7 +4,6 @@ import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
-import useTheme from "@mui/material/styles/useTheme";
 import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppContext } from "../AppContext";
@@ -19,7 +18,6 @@ export default function AllocRoundView() {
   Logger.logPrefix = "AllocRoundView";
   const { roles } = useRoleLoggedIn();
   const navigate = useNavigate();
-  const theme = useTheme();
   const pageSize = useContext(AppContext).settings.itemsPerPage;
 
   const [paginateAllocRounds, setpaginateAllocRounds] = useState([]);


### PR DESCRIPTION
Getting the styling for the buttons through classes instead of importing useTheme -> makes code shorter and easier to understand.

Also, was able to get rid of the rest of the hardcoded colors in buttons, so now all the buttons should get their colors from the theme file.  