### PR TITLE
getting rid of hardcoded colors of some icons and pagination

### DIFF
--- a/src/components/department/Departments.jsx
+++ b/src/components/department/Departments.jsx
@@ -92,7 +92,6 @@ export default function Departments() {
                 count={totalCount}
                 page={page}
                 onChange={handlePageChange}
-                color="primary"
                 variant="outlined"
               />
             </CardContent>

--- a/src/components/result/CollapsedRow.jsx
+++ b/src/components/result/CollapsedRow.jsx
@@ -16,17 +16,14 @@ export default function CollapsedRow({ prog1 }) {
     <Grid2 container>
       {expand ? (
         <KeyboardArrowUpIcon
-          sx={{ fontSize: 24, color: theme.palette.infoIcon.main }}
+          className="infoIcon arrowUpDownIcon"
           onClick={() => setExpand(!expand)}
         >
           {" "}
         </KeyboardArrowUpIcon>
       ) : (
         <KeyboardArrowDownIcon
-          sx={{
-            fontSize: 24,
-            color: theme.palette.infoIcon.main,
-          }}
+          className="infoIcon arrowUpDownIcon"
           onClick={() => setExpand(!expand)}
         >
           {" "}

--- a/src/components/result/CollapsedRowB.jsx
+++ b/src/components/result/CollapsedRowB.jsx
@@ -37,12 +37,15 @@ export default function CollapsedRowB({ id }) {
   return (
     <Grid2 container>
       {expand ? (
-        <KeyboardArrowUpIcon sx={{ fontSize: 24 }} onClick={handleExpandClick}>
+        <KeyboardArrowUpIcon
+          className="infoIcon arrowUpDownIcon"
+          onClick={handleExpandClick}
+        >
           {" "}
         </KeyboardArrowUpIcon>
       ) : (
         <KeyboardArrowDownIcon
-          sx={{ color: theme.palette.infoIcon.main, fontSize: 24 }}
+          className="infoIcon arrowUpDownIcon"
           onClick={handleExpandClick}
         >
           {" "}

--- a/src/components/result/SubjectResult.jsx
+++ b/src/components/result/SubjectResult.jsx
@@ -78,14 +78,14 @@ function CollapsedRow(id) {
     <Grid2 container>
       {expand ? (
         <KeyboardArrowUpIcon
-          sx={{ color: theme.palette.primary, fontSize: 24 }}
+          className="infoIcon arrowUpDownIcon"
           onClick={() => setExpand(!expand)}
         >
           {" "}
         </KeyboardArrowUpIcon>
       ) : (
         <KeyboardArrowDownIcon
-          sx={{ color: theme.palette.primary, fontSize: 24 }}
+          className="infoIcon arrowUpDownIcon"
           onClick={() => {
             getRoomsData();
             setExpand(!expand);

--- a/src/components/resultFailureReasons/GetMissingEquipment.jsx
+++ b/src/components/resultFailureReasons/GetMissingEquipment.jsx
@@ -63,11 +63,11 @@ export function GetMissingEquipment({ subjId, roomId, missingEquipmentCount }) {
     <Tooltip disableFocusListener title={missingEquipment}>
       {missingEquipmentCount > 0 ? (
         <TableCell>
-          <CloseIcon color="error" />
+          <CloseIcon className="redIcon" />
         </TableCell>
       ) : (
         <TableCell>
-          <CheckIcon color="success" />
+          <CheckIcon className="greenIcon" />
         </TableCell>
       )}
     </Tooltip>

--- a/src/components/spaceType/AddSpaceTypeContainer.jsx
+++ b/src/components/spaceType/AddSpaceTypeContainer.jsx
@@ -114,7 +114,6 @@ export default function AddSpaceTypeContainer({ getAllSpaceTypes }) {
                 onClick={() => setIsCardExpanded(!isCardExpanded)}
                 aria-expanded={isCardExpanded}
                 aria-label="expand/collapse"
-                color="primary"
               >
                 {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
               </IconButton>

--- a/src/components/spaceType/SingleSpaceTypeDialog.jsx
+++ b/src/components/spaceType/SingleSpaceTypeDialog.jsx
@@ -28,7 +28,6 @@ export default function SingleSpaceTypeDialog({
       </DialogTitle>
       <IconButton
         edge="end"
-        color="inherit"
         onClick={() => setOpen(false)}
         aria-label="close"
         style={{ position: "absolute", top: "10px", right: "20px" }}

--- a/src/components/spaceType/SpaceTypeListPagination.jsx
+++ b/src/components/spaceType/SpaceTypeListPagination.jsx
@@ -32,11 +32,6 @@ export default function SpaceTypePagination({
   };
 
   return (
-    <Pagination
-      count={count}
-      color="primary"
-      onChange={handleChange}
-      variant="outlined"
-    />
+    <Pagination count={count} onChange={handleChange} variant="outlined" />
   );
 }

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -29,6 +29,24 @@ export const createAppTheme = (currentPalette) =>
   createTheme({
     palette: currentPalette,
     components: {
+      MuiSvgIcon: {
+        styleOverrides: {
+          root: {
+            "&.redIcon": {
+              color: currentPalette.warning.main,
+            },
+            "&.greenIcon": {
+              color: currentPalette.success.main,
+            },
+            "&.infoIcon": {
+              color: currentPalette.infoIcon.main,
+            },
+            "&.arrowUpDownIcon": {
+              fontSize: 25,
+            },
+          },
+        },
+      },
       MuiCheckbox: {
         styleOverrides: {
           root: {
@@ -556,6 +574,9 @@ export const createAppTheme = (currentPalette) =>
             button: {
               color: currentPalette.fontColorDefault.default,
               borderColor: currentPalette.borderColor.main,
+              "&:hover": {
+                backgroundColor: `${currentPalette.backgroundDarker.default}175`,
+              },
             },
             "& .MuiPaginationItem-page.Mui-selected": {
               backgroundColor: `${currentPalette.primary.main}25`,

--- a/src/views/AllocationSubjectFailureView.jsx
+++ b/src/views/AllocationSubjectFailureView.jsx
@@ -264,11 +264,11 @@ export default function AllocationSubjectFailureView() {
                       >
                         {row.areaOk === 0 ? (
                           <TableCell>
-                            <CloseIcon color="error" />
+                            <CloseIcon className="redIcon" />
                           </TableCell>
                         ) : (
                           <TableCell>
-                            <CheckIcon color="success" />
+                            <CheckIcon className="greenIcon" />
                           </TableCell>
                         )}
                       </Tooltip>
@@ -278,11 +278,11 @@ export default function AllocationSubjectFailureView() {
                       >
                         {row.personLimitOk === 0 ? (
                           <TableCell>
-                            <CloseIcon color="error" />
+                            <CloseIcon className="redIcon" />
                           </TableCell>
                         ) : (
                           <TableCell>
-                            <CheckIcon color="success" />
+                            <CheckIcon className="greenIcon" />
                           </TableCell>
                         )}
                       </Tooltip>
@@ -295,11 +295,11 @@ export default function AllocationSubjectFailureView() {
                       >
                         {row.spaceTypeOk === 0 ? (
                           <TableCell>
-                            <CloseIcon color="error" />
+                            <CloseIcon className="redIcon" />
                           </TableCell>
                         ) : (
                           <TableCell>
-                            <CheckIcon color="success" />
+                            <CheckIcon className="greenIcon" />
                           </TableCell>
                         )}
                       </Tooltip>

--- a/src/views/NotFoundView.jsx
+++ b/src/views/NotFoundView.jsx
@@ -2,7 +2,7 @@ import Typography from "@mui/material/Typography";
 
 export default function NotFoundView() {
   return (
-    <Typography variant="body1" color="secondary">
+    <Typography variant="body1">
       Unfortunately this navigation Route does not exist!
     </Typography>
   );


### PR DESCRIPTION
Making classes for the different colored icons in the theme file and applying those classes instead of hardcoding. Also, got rid of the hardcoded colors for pagination. 