### PR TITLE
Fixed itemsPerPage setting not working

### DIFF
--- a/src/setting/handleSettings.js
+++ b/src/setting/handleSettings.js
@@ -17,7 +17,7 @@ export const handleSettings = (settings, appContext) => {
   Logger.debug("Handling settings");
 
   const itemsPerPage = settings.find(
-    (setting) => setting?.name?.toLowerCase() === "items-per-page",
+    (setting) => setting?.variable?.toLowerCase() === "items-per-page",
   );
   if (itemsPerPage) {
     appContext.settings.itemsPerPage = itemsPerPage.numberValue;


### PR DESCRIPTION
itemsPerPage setting broke and always used default value because of the recent setting column change in the settings database table.