### PR TITLE
Fixed alerts not showing up

### DIFF
--- a/src/components/common/AlertBox.jsx
+++ b/src/components/common/AlertBox.jsx
@@ -12,9 +12,9 @@ export default function AlertBox({ alertOpen, alertOptions, setAlertOpen }) {
   return (
     <div>
       <Snackbar
-        snackopen={alertOpen !== "false" && alertOpen ? "true" : "false"}
+        open={alertOpen}
         autoHideDuration={4000}
-        onClose={setAlertOpen}
+        onClose={() => setAlertOpen(false)}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       >
         <Alert


### PR DESCRIPTION
Replaced AlertBox Snackbar 'snackopen' prop with 'open'. snackopen prop didn't do anything because the prop does not exist in Snackbar. Also fixed a warning about the 'open' prop having invalid type.

Let me know if you can still find warnings about the AlertBox.