### PR TITLE
change import Exceljs to exceljs

### DIFF
--- a/src/importDataFunctions/getFullReport.js
+++ b/src/importDataFunctions/getFullReport.js
@@ -1,4 +1,4 @@
-import * as ExcelJS from "Exceljs";
+import * as ExcelJS from "exceljs";
 import dao from "../ajax/dao";
 
 export const getFullReport = async (sheetcolumns, saveAs, setAlertOptions) => {

--- a/src/importDataFunctions/getPlannerData.js
+++ b/src/importDataFunctions/getPlannerData.js
@@ -1,4 +1,4 @@
-import * as ExcelJS from "Exceljs";
+import * as ExcelJS from "exceljs";
 import dao from "../ajax/dao";
 
 export const getPlannerData = async (

--- a/src/importDataFunctions/getReportData.js
+++ b/src/importDataFunctions/getReportData.js
@@ -1,4 +1,4 @@
-import * as ExcelJS from "Exceljs";
+import * as ExcelJS from "exceljs";
 import dao from "../ajax/dao";
 
 export const getReportData = async (


### PR DESCRIPTION
There was a vite build time error when running 'npm run build' during Docker image build process. 
`Error: [vite]: Rollup failed to resolve import "Exceljs" from "/app/src/importDataFunctions/getFullReport.js"`

After the changes it went away.