### PR TITLE
Removed alert from reset data action and added a new alertOption change in const resetDatabase

### DIFF
--- a/src/routers/Nav.jsx
+++ b/src/routers/Nav.jsx
@@ -165,8 +165,6 @@ export default function NavBar() {
             content: "By clicking continue, you will reset the database.",
           });
           setdBResetDialogOpen(true);
-        } else {
-          alert("Not in development mode!");
         }
       },
     },
@@ -311,7 +309,7 @@ export default function NavBar() {
         message: "Database was reset.",
       });
       Logger.debug("reset database success");
-    } else {
+    } else if (result.httpStatus !== 400) {
       setAlertOptions({
         severity: "error",
         title: "Error",
@@ -320,6 +318,12 @@ export default function NavBar() {
       Logger.error(
         `failed to reset database, http status code: ${result.httpStatus}`,
       );
+    } else {
+      setAlertOptions({
+        severity: "error",
+        title: "Error",
+        message: "Not in development mode!",
+      });
     }
     setAlertOpen(true);
   };


### PR DESCRIPTION
Removed the alert("Not in development mode!") from the reset data action and made it use alertbox. If httpStatus is exactly 400, it will inform that not in development mode.

But I was wondering, should it just say "Something went wrong..." even here? Or is it fine to tell the user that it is only a development mode button?