### PR TITLE
Making the views for the lists look similar

### DIFF
--- a/src/components/allocRound/AllocRoundListContainer.jsx
+++ b/src/components/allocRound/AllocRoundListContainer.jsx
@@ -14,7 +14,7 @@ export default function AllocRoundListContainer({
   return (
     <div>
       <Container maxWidth="xl">
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <AllocRoundList

--- a/src/components/building/BuildingListContainer.jsx
+++ b/src/components/building/BuildingListContainer.jsx
@@ -11,7 +11,7 @@ export default function BuildingListContainer({
 }) {
   return (
     <Container maxWidth="xl">
-      <Grid container spacing={1}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <BuildingList

--- a/src/components/department/DepartmentListContainer.jsx
+++ b/src/components/department/DepartmentListContainer.jsx
@@ -25,7 +25,7 @@ export default function DepartmentListContainer({
         setOpen={setOpen}
         getAllDepartments={getAllDepartments}
       />
-      <Grid container rowSpacing={1}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <DepartmentList

--- a/src/components/department/Departments.jsx
+++ b/src/components/department/Departments.jsx
@@ -74,7 +74,7 @@ export default function Departments() {
         {roles.admin === "1" && (
           <AddDepartment getAllDepartments={getAllDepartments} />
         )}
-        <Grid container rowSpacing={0.5}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Departments" variant="pageHeader" />

--- a/src/components/equipment/EquipmentListContainer.jsx
+++ b/src/components/equipment/EquipmentListContainer.jsx
@@ -24,7 +24,7 @@ export default function EquipmentListContainer({
         setOpen={setOpen}
         getAllEquipments={getAllEquipments}
       />
-      <Grid container rowSpacing={1}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <EquipmentList

--- a/src/components/equipment/Equipments.jsx
+++ b/src/components/equipment/Equipments.jsx
@@ -72,7 +72,7 @@ export default function Equipments() {
         {roles.admin === "1" && (
           <AddEquipment getAllEquipments={getAllEquipments} />
         )}
-        <Grid container rowSpacing={0.5}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Equipment" variant="pageHeader" />

--- a/src/components/program/ProgramListContainer.jsx
+++ b/src/components/program/ProgramListContainer.jsx
@@ -24,7 +24,7 @@ export default function ProgramListContainer({
         getAllPrograms={getAllPrograms}
       />
 
-      <Grid container spacing={2}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <ProgramList

--- a/src/components/settings/SettingsListContainer.jsx
+++ b/src/components/settings/SettingsListContainer.jsx
@@ -10,7 +10,7 @@ export default function SettingsListContainer({
 }) {
   return (
     <div>
-      <Grid container rowSpacing={0.5}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <SettingsList

--- a/src/components/space/SpaceListContainer.jsx
+++ b/src/components/space/SpaceListContainer.jsx
@@ -24,7 +24,7 @@ export default function SpaceListContainer({
         onClose={() => setOpen(false)}
       />
 
-      <Grid container spacing={2}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <SpaceList

--- a/src/components/spaceType/SpaceTypeListContainer.jsx
+++ b/src/components/spaceType/SpaceTypeListContainer.jsx
@@ -11,7 +11,7 @@ export default function SpaceTypeListContainer({
 }) {
   return (
     <Container maxWidth="xl">
-      <Grid container spacing={1}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <SpaceTypeList

--- a/src/components/subject/SubjectListContainer.jsx
+++ b/src/components/subject/SubjectListContainer.jsx
@@ -26,7 +26,7 @@ export default function SubjectListContainer({
         userPrograms={userPrograms}
       />
 
-      <Grid container spacing={2}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <SubjectList

--- a/src/components/user/UserListContainer.jsx
+++ b/src/components/user/UserListContainer.jsx
@@ -10,7 +10,7 @@ export default function UserListContainer({
 }) {
   return (
     <div>
-      <Grid container rowSpacing={1}>
+      <Grid container rowSpacing={2}>
         <Card variant="outlined">
           <CardContent>
             <UserList

--- a/src/views/BuildingView.jsx
+++ b/src/views/BuildingView.jsx
@@ -74,8 +74,8 @@ export default function BuildingView() {
         )}
         <Grid container rowSpacing={1}>
           <Card variant="outlined">
-            <CardHeader title="Buildings" variant="pageHeader" />
             <CardContent>
+              <CardHeader title="Buildings" variant="pageHeader" />
               <BuildingListContainer
                 getAllBuildings={getAllBuildings}
                 allBuildingsList={allBuildingsList}

--- a/src/views/BuildingView.jsx
+++ b/src/views/BuildingView.jsx
@@ -72,7 +72,7 @@ export default function BuildingView() {
         {roles.admin === "1" && (
           <AddBuildingContainer getAllBuildings={getAllBuildings} />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Buildings" variant="pageHeader" />

--- a/src/views/ProgramView.jsx
+++ b/src/views/ProgramView.jsx
@@ -87,8 +87,8 @@ export default function ProgramView() {
         )}
         <Grid container rowSpacing={1}>
           <Card variant="outlined">
-            <CardHeader title="Programs" variant="pageHeader" />
             <CardContent>
+              <CardHeader title="Programs" variant="pageHeader" />
               <ProgramListContainer
                 getAllPrograms={getAllPrograms}
                 allProgramsList={allProgramsList}

--- a/src/views/ProgramView.jsx
+++ b/src/views/ProgramView.jsx
@@ -85,7 +85,7 @@ export default function ProgramView() {
             allProgramsList={allProgramsList}
           />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Programs" variant="pageHeader" />

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -94,7 +94,7 @@ export default function SettingsView() {
         {roles.admin === "1" && (
           <AddSettingContainer getAllSettings={getAllSettings} />
         )}
-        <Grid container rowSpacing={0.5}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader

--- a/src/views/SpaceTypeView.jsx
+++ b/src/views/SpaceTypeView.jsx
@@ -72,7 +72,7 @@ export default function SpaceTypeView() {
         {roles.admin === "1" && (
           <AddSpaceTypeContainer getAllSpaceTypes={getAllSpaceTypes} />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Space Types" variant="pageHeader" />

--- a/src/views/SpaceTypeView.jsx
+++ b/src/views/SpaceTypeView.jsx
@@ -74,8 +74,8 @@ export default function SpaceTypeView() {
         )}
         <Grid container rowSpacing={1}>
           <Card variant="outlined">
-            <CardHeader title="Space Types" variant="pageHeader" />
             <CardContent>
+              <CardHeader title="Space Types" variant="pageHeader" />
               <SpaceTypeListContainer
                 getAllSpaceTypes={getAllSpaceTypes}
                 allSpaceTypesList={allSpaceTypesList}

--- a/src/views/SpaceView.jsx
+++ b/src/views/SpaceView.jsx
@@ -122,8 +122,8 @@ export default function SpaceView() {
         )}
         <Grid container rowSpacing={1}>
           <Card variant="outlined">
-            <CardHeader title="Spaces" variant="pageHeader" />
             <CardContent>
+              <CardHeader title="Spaces" variant="pageHeader" />
               <SpaceListContainer
                 shownSpace={shownSpace}
                 setShownSpace={setShownSpace}

--- a/src/views/SpaceView.jsx
+++ b/src/views/SpaceView.jsx
@@ -120,7 +120,7 @@ export default function SpaceView() {
         {roles.admin === "1" && (
           <AddSpace getAllSpaces={getAllSpaces} allSpacesList={allSpacesList} />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Spaces" variant="pageHeader" />

--- a/src/views/SubjectView.jsx
+++ b/src/views/SubjectView.jsx
@@ -177,7 +177,7 @@ export default function SubjectView() {
             allSubjectsList={allSubjectsList}
           />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader

--- a/src/views/SubjectView.jsx
+++ b/src/views/SubjectView.jsx
@@ -179,18 +179,18 @@ export default function SubjectView() {
         )}
         <Grid container rowSpacing={1}>
           <Card variant="outlined">
-            <CardHeader
-              title={
-                <>
-                  Lessons in allocation -
-                  <span className="allocRoundHeader">
-                    {` ${allocRoundContext.allocRoundId} : ${allocRoundContext.allocRoundName}`}
-                  </span>
-                </>
-              }
-              variant="pageHeader"
-            />
             <CardContent>
+              <CardHeader
+                title={
+                  <>
+                    Lessons in allocation -
+                    <span className="allocRoundHeader">
+                      {` ${allocRoundContext.allocRoundId} : ${allocRoundContext.allocRoundName}`}
+                    </span>
+                  </>
+                }
+                variant="pageHeader"
+              />
               <SubjectListContainer
                 shownSubject={shownSubject}
                 setShownSubject={setShownSubject2}

--- a/src/views/UserView.jsx
+++ b/src/views/UserView.jsx
@@ -85,7 +85,7 @@ export default function UserView() {
         {roles.admin === "1" && (
           <AddUser getAllUsers={getAllUsers} allUsersList={allUsersList} />
         )}
-        <Grid container rowSpacing={1}>
+        <Grid container rowSpacing={2}>
           <Card variant="outlined">
             <CardContent>
               <CardHeader title="Users" variant="pageHeader" />


### PR DESCRIPTION
Corrected the rowspacing in all of the views so it looks more coherent. Also put all the cardheaders inside the cardcontent. Overall, looks better. I'll see if there's a way to determine the rowspacing for all cards in one place but for now it works. 