### PR TITLE
Fixed copy allocround so it shows validation errors when add is pressed

### DIFF
--- a/src/components/allocRound/AddEmptyAllocRound.jsx
+++ b/src/components/allocRound/AddEmptyAllocRound.jsx
@@ -54,7 +54,7 @@ export const AddEmptyAllocRound = ({ allAllocRoundsList }) => {
     },
   });
 
-  const resetFormm = () => {
+  const resetForm = () => {
     setInitialAllocRound({
       name: "",
       description: "",
@@ -84,7 +84,7 @@ export const AddEmptyAllocRound = ({ allAllocRoundsList }) => {
       message: `${submitValues.name} added successfully.`,
     });
     setAlertOpen(true);
-    resetFormm();
+    resetForm();
     // getAllAllocRounds();
   };
   return (

--- a/src/components/allocRound/CopyAllocRound.jsx
+++ b/src/components/allocRound/CopyAllocRound.jsx
@@ -27,7 +27,8 @@ export const CopyAllocRound = ({ allAllocRoundsList }) => {
   const [initialAllocRound, setInitialEmptyAllocRound] = useState({
     name: "",
     description: "",
-    copiedAllocRoundId: "",
+    copiedAllocRoundId:
+      allAllocRoundsList.length > 0 ? allAllocRoundsList[0].id : "",
   });
 
   const formik = useFormik({
@@ -54,10 +55,10 @@ export const CopyAllocRound = ({ allAllocRoundsList }) => {
     });
   };
 
-  const handleCopyAllocRoundSubmit = async (event) => {
-    event.preventDefault();
-    formik.handleSubmit();
-    const { name, description, copiedAllocRoundId } = formik.values;
+  const handleCopyAllocRoundSubmit = async (submitValues) => {
+    const name = submitValues.name;
+    const description = submitValues.description;
+    const copiedAllocRoundId = submitValues.copiedAllocRoundId;
 
     Logger.debug(
       `Trying to create a copy of alloc round with: ${name},${description},${copiedAllocRoundId},${userId}`,

--- a/src/components/allocRound/CopyAllocRound.jsx
+++ b/src/components/allocRound/CopyAllocRound.jsx
@@ -56,6 +56,7 @@ export const CopyAllocRound = ({ allAllocRoundsList }) => {
 
   const handleCopyAllocRoundSubmit = async (event) => {
     event.preventDefault();
+    formik.handleSubmit();
     const { name, description, copiedAllocRoundId } = formik.values;
 
     Logger.debug(

--- a/src/components/allocRound/CopyAllocRoundContainer.jsx
+++ b/src/components/allocRound/CopyAllocRoundContainer.jsx
@@ -15,7 +15,7 @@ export default function CopyAllocRoundContainer({
 
   return (
     <div>
-      <form onSubmit={handleCopyAllocRoundSubmit}>
+      <form onSubmit={formik.handleSubmit}>
         <Grid container variant="sibaGridAddForm" column={8}>
           <CopyAllocRoundForm
             formik={formik}

--- a/src/components/allocRound/CopyAllocRoundForm.jsx
+++ b/src/components/allocRound/CopyAllocRoundForm.jsx
@@ -7,7 +7,9 @@ import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
 
 export default function CopyAllocRoundForm({ formik, allAllocRoundsList }) {
-  const [selectedAllocation, setSelectedAllocation] = useState("");
+  const [selectedAllocation, setSelectedAllocation] = useState(
+    allAllocRoundsList.length > 0 ? allAllocRoundsList[0].id : "",
+  );
 
   const handleAllocationChange = (event) => {
     const selectedAllocationId = event.target.value;


### PR DESCRIPTION
Also made it so that if there are existing allocrounds, in copy allocroud the initial value of the select allocround to copy is the first existing allocation, since that seemed logical. Can change that back if not a desirable behavior