### PR TITLE
Created common containers and applied them for departments and programs

### DIFF
--- a/src/components/common/CommonContainers.jsx
+++ b/src/components/common/CommonContainers.jsx
@@ -1,0 +1,20 @@
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+
+const CommonContainer = ({ children }) => {
+  return <Container maxWidth="xl">{children}</Container>;
+};
+
+const CommonContentContainer = ({ children }) => {
+  return (
+    <Grid container rowSpacing={2}>
+      <Card variant="outlined">
+        <CardContent>{children}</CardContent>
+      </Card>
+    </Grid>
+  );
+};
+
+export { CommonContainer, CommonContentContainer };

--- a/src/components/department/AddDepartment.jsx
+++ b/src/components/department/AddDepartment.jsx
@@ -1,19 +1,17 @@
-import { useFormik } from "formik";
-import { useState } from "react";
-import dao from "../../ajax/dao";
-import { validate } from "../../validation/ValidateAddDepartment";
-
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Button from "@mui/material/Button";
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
+import { useFormik } from "formik";
+import { useState } from "react";
+import dao from "../../ajax/dao";
+import { validate } from "../../validation/ValidateAddDepartment";
 import { capitalizeFirstLetter } from "../../validation/ValidationUtilities";
 import AlertBox from "../common/AlertBox";
+import { CommonContentContainer } from "../common/CommonContainers";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 import DepartmentTemplate from "./DepartmentTemplate";
 import ImportDepartmentContainer from "./ImportDepartmentContainer";
@@ -93,95 +91,93 @@ export default function AddDepartment({ getAllDepartments }) {
         submit={addDepartment}
         submitValues={formik.values}
       />
-      <Card variant="outlined">
-        <CardContent>
-          <CardHeader
-            title="Add Department"
-            onClick={() => setIsCardExpanded(!isCardExpanded)}
-            variant="pageHeader"
-            action={
-              <IconButton
-                onClick={() => setIsCardExpanded(!isCardExpanded)}
-                aria-expanded={isCardExpanded}
-                aria-label="show more"
-              >
-                {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              </IconButton>
-            }
-          />
-          {isCardExpanded && (
-            <form onSubmit={formik.handleSubmit}>
-              <Grid container spacing={2}>
-                <Grid item xs={12} sm={12} md={4} lg={4}>
-                  <TextField
-                    fullWidth
-                    error={
-                      formik.touched.name && formik.errors.name ? true : false
-                    }
-                    name="name"
-                    placeholder="Name..."
-                    label="Department name"
-                    variant="outlined"
-                    value={formik.values.name}
-                    onChange={formik.handleChange("name")}
-                    onBlur={formik.handleBlur("name")}
-                    helperText={
-                      formik.touched.name && formik.errors.name
-                        ? formik.errors.name
-                        : null
-                    }
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
+      <CommonContentContainer>
+        <CardHeader
+          title="Add Department"
+          onClick={() => setIsCardExpanded(!isCardExpanded)}
+          variant="pageHeader"
+          action={
+            <IconButton
+              onClick={() => setIsCardExpanded(!isCardExpanded)}
+              aria-expanded={isCardExpanded}
+              aria-label="show more"
+            >
+              {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            </IconButton>
+          }
+        />
+        {isCardExpanded && (
+          <form onSubmit={formik.handleSubmit}>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={12} md={4} lg={4}>
+                <TextField
+                  fullWidth
+                  error={
+                    formik.touched.name && formik.errors.name ? true : false
+                  }
+                  name="name"
+                  placeholder="Name..."
+                  label="Department name"
+                  variant="outlined"
+                  value={formik.values.name}
+                  onChange={formik.handleChange("name")}
+                  onBlur={formik.handleBlur("name")}
+                  helperText={
+                    formik.touched.name && formik.errors.name
+                      ? formik.errors.name
+                      : null
+                  }
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                />
+              </Grid>
+              <Grid item xs={12} sm={12} md={8} lg={8}>
+                <TextField
+                  fullWidth
+                  error={
+                    formik.touched.description && formik.errors.description
+                      ? true
+                      : false
+                  }
+                  name="description"
+                  label="Description"
+                  placeholder="Some description..."
+                  variant="outlined"
+                  value={formik.values.description}
+                  onChange={formik.handleChange("description")}
+                  onBlur={formik.handleBlur("description")}
+                  helperText={
+                    formik.touched.description && formik.errors.description
+                      ? formik.errors.description
+                      : null
+                  }
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Button
+                  type="submit"
+                  variant="addComponentFormButton"
+                  onClick={() => {
+                    setInitialDepartment(formik.values);
+                  }}
+                >
+                  Add Department
+                </Button>
+                <Grid padding={2}>
+                  <ImportDepartmentContainer
+                    getAllDepartments={getAllDepartments}
                   />
-                </Grid>
-                <Grid item xs={12} sm={12} md={8} lg={8}>
-                  <TextField
-                    fullWidth
-                    error={
-                      formik.touched.description && formik.errors.description
-                        ? true
-                        : false
-                    }
-                    name="description"
-                    label="Description"
-                    placeholder="Some description..."
-                    variant="outlined"
-                    value={formik.values.description}
-                    onChange={formik.handleChange("description")}
-                    onBlur={formik.handleBlur("description")}
-                    helperText={
-                      formik.touched.description && formik.errors.description
-                        ? formik.errors.description
-                        : null
-                    }
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
-                  />
-                </Grid>
-                <Grid item xs={12}>
-                  <Button
-                    type="submit"
-                    variant="addComponentFormButton"
-                    onClick={() => {
-                      setInitialDepartment(formik.values);
-                    }}
-                  >
-                    Add Department
-                  </Button>
-                  <Grid padding={2}>
-                    <ImportDepartmentContainer
-                      getAllDepartments={getAllDepartments}
-                    />
-                    <DepartmentTemplate />
-                  </Grid>
+                  <DepartmentTemplate />
                 </Grid>
               </Grid>
-            </form>
-          )}
-        </CardContent>
-      </Card>
+            </Grid>
+          </form>
+        )}
+      </CommonContentContainer>
     </>
   );
 }

--- a/src/components/department/DepartmentListContainer.jsx
+++ b/src/components/department/DepartmentListContainer.jsx
@@ -25,22 +25,16 @@ export default function DepartmentListContainer({
         setOpen={setOpen}
         getAllDepartments={getAllDepartments}
       />
-      <Grid container rowSpacing={2}>
-        <Card variant="outlined">
-          <CardContent>
-            <DepartmentList
-              getAllDepartments={getAllDepartments}
-              departmentList={departmentList}
-              paginateDepartment={paginateDepartment}
-              setPaginateDepartment={setPaginateDepartment}
-              pagination={pagination}
-              setPagination={setPagination}
-              totalCount={totalCount}
-              rowsPerPage={rowsPerPage}
-            />
-          </CardContent>
-        </Card>
-      </Grid>
+      <DepartmentList
+        getAllDepartments={getAllDepartments}
+        departmentList={departmentList}
+        paginateDepartment={paginateDepartment}
+        setPaginateDepartment={setPaginateDepartment}
+        pagination={pagination}
+        setPagination={setPagination}
+        totalCount={totalCount}
+        rowsPerPage={rowsPerPage}
+      />
     </div>
   );
 }

--- a/src/components/department/Departments.jsx
+++ b/src/components/department/Departments.jsx
@@ -1,4 +1,6 @@
+import CardHeader from "@mui/material/CardHeader";
 import { useContext, useEffect, useState } from "react";
+import { AppContext } from "../../AppContext";
 import {
   ajaxRequestErrorHandler,
   getFunctionName,
@@ -6,13 +8,10 @@ import {
 import dao from "../../ajax/dao";
 import { useRoleLoggedIn } from "../../hooks/useRoleLoggedIn";
 import Logger from "../../logger/logger";
-
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import CardHeader from "@mui/material/CardHeader";
-import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
-import { AppContext } from "../../AppContext";
+import {
+  CommonContainer,
+  CommonContentContainer,
+} from "../common/CommonContainers";
 import AddDepartment from "./AddDepartment";
 import DepartmentListContainer from "./DepartmentListContainer";
 
@@ -70,28 +69,24 @@ export default function Departments() {
 
   return (
     <div>
-      <Container maxWidth="100%">
+      <CommonContainer>
         {roles.admin === "1" && (
           <AddDepartment getAllDepartments={getAllDepartments} />
         )}
-        <Grid container rowSpacing={2}>
-          <Card variant="outlined">
-            <CardContent>
-              <CardHeader title="Departments" variant="pageHeader" />
-              <DepartmentListContainer
-                getAllDepartments={getAllDepartments}
-                departmentList={departmentList}
-                paginateDepartment={paginateDepartment}
-                setPaginateDepartment={setPaginateDepartment}
-                pagination={pagination}
-                setPagination={setPagination}
-                totalCount={totalCount}
-                rowsPerPage={rowsPerPage}
-              />
-            </CardContent>
-          </Card>
-        </Grid>
-      </Container>
+        <CommonContentContainer>
+          <CardHeader title="Departments" variant="pageHeader" />
+          <DepartmentListContainer
+            getAllDepartments={getAllDepartments}
+            departmentList={departmentList}
+            paginateDepartment={paginateDepartment}
+            setPaginateDepartment={setPaginateDepartment}
+            pagination={pagination}
+            setPagination={setPagination}
+            totalCount={totalCount}
+            rowsPerPage={rowsPerPage}
+          />
+        </CommonContentContainer>
+      </CommonContainer>
     </div>
   );
 }

--- a/src/components/program/AddProgramContainer.jsx
+++ b/src/components/program/AddProgramContainer.jsx
@@ -1,8 +1,5 @@
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Typography } from "@mui/material";
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import IconButton from "@mui/material/IconButton";
 import { useFormik } from "formik";
@@ -19,6 +16,7 @@ import Logger from "../../logger/logger";
 import { validate } from "../../validation/ValidateAddProgram";
 import { capitalizeFirstLetter } from "../../validation/ValidationUtilities";
 import AlertBox from "../common/AlertBox";
+import { CommonContentContainer } from "../common/CommonContainers";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 import AddProgramForm from "./AddProgramForm";
 import ImportProgramContainer from "./ImportProgramContainer";
@@ -172,40 +170,38 @@ export default function AddProgramContainer({
         submit={addProgram}
         submitValues={formik.values}
       />
-      <Card variant="outlined">
-        <CardContent>
-          <CardHeader
-            title="Add Program"
-            variant="pageHeader"
-            action={
-              <IconButton
-                onClick={() => setIsCardExpanded(!isCardExpanded)}
-                aria-expanded={isCardExpanded}
-                aria-label="expand/collapse"
-              >
-                {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              </IconButton>
-            }
-          />
-          {isCardExpanded && (
-            <>
-              <AddProgramForm
-                handleChange={handleChange}
-                formik={formik}
-                submitValues={formik.values}
-                setInitialProgram={setInitialProgram}
-                allProgramsList={allProgramsList}
-                departmentSelectList={departmentSelectList}
-              />
-              <ImportProgramContainer
-                getAllPrograms={getAllPrograms}
-                departmentSelectList={departmentSelectList}
-              />
-              <ProgramTemplate />
-            </>
-          )}
-        </CardContent>
-      </Card>
+      <CommonContentContainer>
+        <CardHeader
+          title="Add Program"
+          variant="pageHeader"
+          action={
+            <IconButton
+              onClick={() => setIsCardExpanded(!isCardExpanded)}
+              aria-expanded={isCardExpanded}
+              aria-label="expand/collapse"
+            >
+              {isCardExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            </IconButton>
+          }
+        />
+        {isCardExpanded && (
+          <>
+            <AddProgramForm
+              handleChange={handleChange}
+              formik={formik}
+              submitValues={formik.values}
+              setInitialProgram={setInitialProgram}
+              allProgramsList={allProgramsList}
+              departmentSelectList={departmentSelectList}
+            />
+            <ImportProgramContainer
+              getAllPrograms={getAllPrograms}
+              departmentSelectList={departmentSelectList}
+            />
+            <ProgramTemplate />
+          </>
+        )}
+      </CommonContentContainer>
     </div>
   );
 }

--- a/src/components/program/AddProgramForm.jsx
+++ b/src/components/program/AddProgramForm.jsx
@@ -60,7 +60,7 @@ export default function AddProgramForm({
             </FormControl>
           </Grid>
         </Grid>
-        <Grid item xs={3} padding={2}>
+        <Grid item xs={12} padding={2}>
           <Button
             type="submit"
             variant="addComponentFormButton"

--- a/src/components/program/ProgramListContainer.jsx
+++ b/src/components/program/ProgramListContainer.jsx
@@ -1,7 +1,3 @@
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
 import { useState } from "react";
 import ProgramList from "./ProgramList";
 import SingleProgramDialog from "./SingleProgramDialog";
@@ -24,20 +20,14 @@ export default function ProgramListContainer({
         getAllPrograms={getAllPrograms}
       />
 
-      <Grid container rowSpacing={2}>
-        <Card variant="outlined">
-          <CardContent>
-            <ProgramList
-              getAllPrograms={getAllPrograms}
-              allProgramsList={allProgramsList}
-              paginatePrograms={paginatePrograms}
-              setPaginatePrograms={setPaginatePrograms}
-              pagination={pagination}
-              setPagination={setPagination}
-            />
-          </CardContent>
-        </Card>
-      </Grid>
+      <ProgramList
+        getAllPrograms={getAllPrograms}
+        allProgramsList={allProgramsList}
+        paginatePrograms={paginatePrograms}
+        setPaginatePrograms={setPaginatePrograms}
+        pagination={pagination}
+        setPagination={setPagination}
+      />
     </div>
   );
 }

--- a/src/views/ProgramView.jsx
+++ b/src/views/ProgramView.jsx
@@ -1,3 +1,4 @@
+import CardHeader from "@mui/material/CardHeader";
 // The programs Page
 import { useContext, useEffect, useState } from "react";
 import { AppContext } from "../AppContext";
@@ -6,17 +7,15 @@ import {
   getFunctionName,
 } from "../ajax/ajaxRequestErrorHandler";
 import dao from "../ajax/dao";
-import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
-import Logger from "../logger/logger";
-
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import CardHeader from "@mui/material/CardHeader";
-import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
 import AlertBox from "../components/common/AlertBox";
+import {
+  CommonContainer,
+  CommonContentContainer,
+} from "../components/common/CommonContainers";
 import AddProgramContainer from "../components/program/AddProgramContainer";
 import ProgramListContainer from "../components/program/ProgramListContainer";
+import { useRoleLoggedIn } from "../hooks/useRoleLoggedIn";
+import Logger from "../logger/logger";
 
 export default function ProgramView() {
   Logger.logPrefix = "ProgramView";
@@ -78,31 +77,27 @@ export default function ProgramView() {
         alertOptions={alertOptions}
         setAlertOpen={setAlertOpen}
       />
-      <Container maxWidth="100%">
+      <CommonContainer>
         {(roles.admin === "1" || roles.planner === "1") && (
           <AddProgramContainer
             getAllPrograms={getAllPrograms}
             allProgramsList={allProgramsList}
           />
         )}
-        <Grid container rowSpacing={2}>
-          <Card variant="outlined">
-            <CardContent>
-              <CardHeader title="Programs" variant="pageHeader" />
-              <ProgramListContainer
-                getAllPrograms={getAllPrograms}
-                allProgramsList={allProgramsList}
-                paginatePrograms={paginatePrograms}
-                setPaginatePrograms={setPaginatePrograms}
-                pagination={pagination}
-                setPagination={setPagination}
-                open={open}
-                setOpen={setOpen}
-              />
-            </CardContent>
-          </Card>
-        </Grid>
-      </Container>
+        <CommonContentContainer>
+          <CardHeader title="Programs" variant="pageHeader" />
+          <ProgramListContainer
+            getAllPrograms={getAllPrograms}
+            allProgramsList={allProgramsList}
+            paginatePrograms={paginatePrograms}
+            setPaginatePrograms={setPaginatePrograms}
+            pagination={pagination}
+            setPagination={setPagination}
+            open={open}
+            setOpen={setOpen}
+          />
+        </CommonContentContainer>
+      </CommonContainer>
     </div>
   );
 }


### PR DESCRIPTION
I tried making common containers that could be re-used in all of the pages, so far only used them in Departments and Programs pages in case there's something that I could get some feedback on. 

CommonContainer is basically for the whole view and the CommonContentContainer is used for the individual components within the container (Add and List). 

I also took out the box in which the lists were wrapped around, we can put it back but let me know what you think, I think it looks a bit cleaner without it. 