### PR TITLE
Making it possible to use a comma in an edit area fields

### DIFF
--- a/src/components/space/EditSpaceForm.jsx
+++ b/src/components/space/EditSpaceForm.jsx
@@ -21,10 +21,16 @@ export default function EditSpaceForm({
 }) {
   const [open, setOpen] = useState(false);
 
-  console.log("inital: ");
-  console.log(formik.initialValues);
-  console.log("changed: ");
-  console.log(formik.values);
+  const compareValues = () => {
+    for (const key in formik.initialValues) {
+      if (
+        formik.values[key].toString() !== formik.initialValues[key].toString()
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
 
   return (
     <div>
@@ -73,11 +79,7 @@ export default function EditSpaceForm({
                   variant="outlined"
                   value={formik.values?.area}
                   onChange={(e) => {
-                    if (e.target.value.endsWith(".")) {
-                      formik.setFieldValue("area", e.target.value);
-                      return;
-                    }
-                    const value = parseFloat(e.target.value);
+                    const value = e.target.value.replace(",", ".");
                     formik.setFieldValue("area", value);
                   }}
                   onBlur={formik.handleBlur("area")}
@@ -299,7 +301,7 @@ export default function EditSpaceForm({
             </Button>
             <Tooltip
               title={
-                formik.dirty ? "" : "Please change values to enable submit"
+                !compareValues() ? "" : "Please change values to enable submit"
               }
               placement="top"
             >
@@ -307,7 +309,7 @@ export default function EditSpaceForm({
                 <Button
                   type="submit"
                   variant="contained"
-                  disabled={!formik.dirty}
+                  disabled={compareValues()}
                   onClick={() => setOpen(false)}
                 >
                   Submit

--- a/src/components/subject/EditSubjectForm.jsx
+++ b/src/components/subject/EditSubjectForm.jsx
@@ -22,6 +22,17 @@ export default function EditSubjectForm({
 }) {
   const [open, setOpen] = useState(false);
 
+  const compareValues = () => {
+    for (const key in formik.initialValues) {
+      if (
+        formik.values[key].toString() !== formik.initialValues[key].toString()
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   return (
     <div>
       <Button
@@ -151,11 +162,7 @@ export default function EditSubjectForm({
                   defaultValue={formik.initialValues?.area}
                   variant="outlined"
                   onChange={(e) => {
-                    if (e.target.value.endsWith(".")) {
-                      formik.setFieldValue("area", e.target.value);
-                      return;
-                    }
-                    const value = parseFloat(e.target.value);
+                    const value = e.target.value.replace(",", ".");
                     formik.setFieldValue("area", value);
                   }}
                   onBlur={formik.handleBlur("area")}
@@ -225,7 +232,7 @@ export default function EditSubjectForm({
             </Button>
             <Tooltip
               title={
-                formik.dirty ? "" : "Please change values to enable submit"
+                !compareValues() ? "" : "Please change values to enable submit"
               }
               placement="top"
             >
@@ -233,7 +240,7 @@ export default function EditSubjectForm({
                 <Button
                   type="submit"
                   variant="contained"
-                  disabled={!formik.dirty}
+                  disabled={compareValues()}
                   onClick={() => {
                     setOpen(false);
                   }}

--- a/src/validation/ValidateAddSubject.js
+++ b/src/validation/ValidateAddSubject.js
@@ -79,7 +79,7 @@ export async function validate(values, allocRoundId) {
       vF_regNumberCountPlus.errorMessageFunction("Session count");
   }
 
-  if (values.area === undefined || values.area === null) {
+  if (values.area === undefined || values.area === null || values.area === "") {
     errors.area = requiredFieldErrorMessageFunction("Area");
   } else if (values.area < 0) {
     errors.area = "The required area cannot be less than 0";

--- a/src/validation/ValidateEditSubject.js
+++ b/src/validation/ValidateEditSubject.js
@@ -95,7 +95,7 @@ export async function validate(values, allocRoundId) {
       vF_regNumberCountPlus.errorMessageFunction("Session count");
   }
 
-  if (values.area === undefined || values.area === null) {
+  if (values.area === undefined || values.area === null || values.area === "") {
     errors.area = requiredFieldErrorMessageFunction("Area");
   } else if (values.area < 0) {
     errors.area = "The required area cannot be less than 0";


### PR DESCRIPTION
I also changed the initial approach to creating a custom comparison function for the Lesson and Subject (because of the float number in area). The previous approach got too hideous.