### PR TITLE
Centralize AllocRoundContext logic in AppContext.js

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,37 +1,22 @@
-import "./App.css";
-import { useThemeSwitcher } from "./hooks/useThemeSwitcher";
-import { AllocRoundContext } from "./AppContext.js";
 import Button from "@mui/material/Button";
 import CssBaseline from "@mui/material/CssBaseline";
 import ThemeProvider from "@mui/material/styles/ThemeProvider";
-import { useEffect, useState } from "react";
+import "./App.css";
+import { AllocRoundProvider } from "./AppContext.js";
+import { useThemeSwitcher } from "./hooks/useThemeSwitcher";
 import Nav from "./routers/Nav";
 import { ThemeIcon } from "./styles/themeIcons";
 
 export default function App() {
   const { theme, toggleTheme } = useThemeSwitcher();
-  const [allocRoundContext, setAllocRoundContext] = useState({
-    allocRoundId: 10004,
-    allocRoundName: "Demo",
-  });
-
-  useEffect(() => {
-    setAllocRoundContext({
-      allocRoundId: Number(localStorage.getItem("allocRoundId")) || 0,
-      allocRoundName:
-        localStorage.getItem("allocRoundName") || "Pick Allocation!",
-    });
-  }, []);
 
   return (
     <div className="App">
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <AllocRoundContext.Provider
-          value={{ allocRoundContext, setAllocRoundContext }}
-        >
+        <AllocRoundProvider>
           <Nav />
-        </AllocRoundContext.Provider>
+        </AllocRoundProvider>
         <Button variant="themeToggle" onClick={toggleTheme}>
           <ThemeIcon theme={theme} />
         </Button>

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useState } from "react";
 
 export const AppContext = createContext({
   // allocRoundId: 10004,
@@ -11,6 +11,22 @@ export const AppContext = createContext({
 });
 
 export const AllocRoundContext = createContext({
-  allocRoundId: 10004,
-  allocRoundName: "Demo",
+  allocRoundId: 0,
+  allocRoundName: "Pick Allocation!",
 });
+
+export const AllocRoundProvider = ({ children }) => {
+  const [allocRoundContext, setAllocRoundContext] = useState({
+    allocRoundId: Number(localStorage.getItem("allocRoundId")) || 0,
+    allocRoundName:
+      localStorage.getItem("allocRoundName") || "Pick Allocation!",
+  });
+
+  return (
+    <AllocRoundContext.Provider
+      value={{ ...allocRoundContext, setAllocRoundContext }}
+    >
+      {children}
+    </AllocRoundContext.Provider>
+  );
+};


### PR DESCRIPTION
1. Moved AllocRoundContext logic in AppContext.js
- state initialization (allocRoundId, allocRoundName) handled within AllocRoundProvider
- context exposes setAllocRoundContext via the provider
2. Default values for AllocRoundContext instead of hardcoded